### PR TITLE
Ditch the chain-callable function approach

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "semi": false,
+  "singleQuote": true,
+  "arrowParens": "always",
+  "trailingComma": "es5"
+}

--- a/generate-function.js
+++ b/generate-function.js
@@ -1,4 +1,4 @@
-const util = require('util')
+const { format: utilFormat } = require('util')
 const jaystring = require('jaystring')
 
 const INDENT_START = /[{[]/
@@ -33,19 +33,23 @@ const genfun = function() {
     push(line)
   }
 
-  const line = function(fmt) {
-    if (!fmt) return line
+  const line = function(fmt, ...args) {
+    if (fmt) line.write(fmt, ...args)
+    return line
+  }
 
-    if (arguments.length === 1 && fmt.indexOf('\n') > -1) {
+  line.write = function(fmt, ...args) {
+    if (typeof fmt !== 'string') throw new Error('Format must be a string!')
+    if (args.length === 1 && fmt.indexOf('\n') > -1) {
+      // multiple lines with no parameters, push them separately for correct indent
       const lines = fmt.trim().split('\n')
-      for (let i = 0; i < lines.length; i++) {
-        pushLine(lines[i].trim())
+      for (const line of lines) {
+        pushLine(line.trim())
       }
     } else {
-      pushLine(util.format.apply(util, arguments))
+      // format + parameters case
+      pushLine(utilFormat(fmt, ...args))
     }
-
-    return line
   }
 
   line.toString = function() {

--- a/generate-function.js
+++ b/generate-function.js
@@ -33,10 +33,7 @@ const genfun = function() {
     push(line)
   }
 
-  const line = function(fmt, ...args) {
-    if (fmt) line.write(fmt, ...args)
-    return line
-  }
+  const line = {}
 
   line.write = function(fmt, ...args) {
     if (typeof fmt !== 'string') throw new Error('Format must be a string!')
@@ -83,8 +80,6 @@ const genfun = function() {
 
     return Function.apply(null, keys.concat(src)).apply(null, vals)
   }
-
-  if (arguments.length) line.apply(null, arguments)
 
   return line
 }

--- a/generate-function.js
+++ b/generate-function.js
@@ -33,9 +33,9 @@ const genfun = function() {
     push(line)
   }
 
-  const line = {}
+  const builder = {}
 
-  line.write = function(fmt, ...args) {
+  builder.write = function(fmt, ...args) {
     if (typeof fmt !== 'string') throw new Error('Format must be a string!')
     if (args.length === 1 && fmt.indexOf('\n') > -1) {
       // multiple lines with no parameters, push them separately for correct indent
@@ -49,11 +49,11 @@ const genfun = function() {
     }
   }
 
-  line.toString = function() {
+  builder.toString = function() {
     return lines.join('\n')
   }
 
-  line.toModule = function(scope) {
+  builder.toModule = function(scope) {
     if (!scope) scope = {}
 
     const scopeSource = Object.entries(scope)
@@ -62,13 +62,13 @@ const genfun = function() {
       })
       .join('\n')
 
-    return `(function() {\n${scopeSource}\nreturn (${line})})();`
+    return `(function() {\n${scopeSource}\nreturn (${builder.toString()})})();`
   }
 
-  line.toFunction = function(scope) {
+  builder.toFunction = function(scope) {
     if (!scope) scope = {}
 
-    const src = 'return (' + line.toString() + ')'
+    const src = 'return (' + builder.toString() + ')'
 
     const keys = Object.keys(scope).map(function(key) {
       return key
@@ -81,7 +81,7 @@ const genfun = function() {
     return Function.apply(null, keys.concat(src)).apply(null, vals)
   }
 
-  return line
+  return builder
 }
 
 module.exports = genfun


### PR DESCRIPTION
There were no real benefits.
The code is cleaner now, and works nicer with prettier.

There were two completely different things named `validate` in one scope, one assigned to another at some point.
    
Also removed 'arguments' usage.

Also added forgotten `.prettierrc`.