### PR TITLE
drop generate-object-property dep

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
-const genobj = require('generate-object-property')
 const jaystring = require('jaystring')
 const genfun = require('./generate-function')
 const jsonpointer = require('jsonpointer')
 const formats = require('./formats')
 const KNOWN_KEYWORDS = require('./known-keywords')
+
+// name is assumed to be already processed and can contain complex paths
+const genobj = (name, property) => `${name}[${JSON.stringify(property)}]`
 
 const get = function(obj, additionalSchemas, ptr) {
   const visit = function(sub) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "test": "tape test/*.js"
   },
   "dependencies": {
-    "generate-object-property": "^1.1.0",
     "jaystring": "^1.0.6",
     "jsonpointer": "^4.0.0"
   },

--- a/test/misc.js
+++ b/test/misc.js
@@ -47,17 +47,17 @@ tape('greedy/false', function(t) {
   });
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 2);
-  t.strictEqual(validate.errors[0].field, 'data.x')
+  t.strictEqual(validate.errors[0].field, 'data["x"]')
   t.strictEqual(validate.errors[0].message, 'is required')
-  t.strictEqual(validate.errors[1].field, 'data.y')
+  t.strictEqual(validate.errors[1].field, 'data["y"]')
   t.strictEqual(validate.errors[1].message, 'is required')
   t.notOk(validate({x: 'string'}), 'should be invalid')
   t.strictEqual(validate.errors.length, 1);
-  t.strictEqual(validate.errors[0].field, 'data.y')
+  t.strictEqual(validate.errors[0].field, 'data["y"]')
   t.strictEqual(validate.errors[0].message, 'is required')
   t.notOk(validate({x: 'string', y: 'value'}), 'should be invalid')
   t.strictEqual(validate.errors.length, 1);
-  t.strictEqual(validate.errors[0].field, 'data.x')
+  t.strictEqual(validate.errors[0].field, 'data["x"]')
   t.strictEqual(validate.errors[0].message, 'is the wrong type')
   t.end();
 });
@@ -76,19 +76,19 @@ tape('greedy/true', function(t) {
   });
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 2);
-  t.strictEqual(validate.errors[0].field, 'data.x')
+  t.strictEqual(validate.errors[0].field, 'data["x"]')
   t.strictEqual(validate.errors[0].message, 'is required')
-  t.strictEqual(validate.errors[1].field, 'data.y')
+  t.strictEqual(validate.errors[1].field, 'data["y"]')
   t.strictEqual(validate.errors[1].message, 'is required')
   t.notOk(validate({x: 'string'}), 'should be invalid')
   t.strictEqual(validate.errors.length, 2);
-  t.strictEqual(validate.errors[0].field, 'data.y')
+  t.strictEqual(validate.errors[0].field, 'data["y"]')
   t.strictEqual(validate.errors[0].message, 'is required')
-  t.strictEqual(validate.errors[1].field, 'data.x')
+  t.strictEqual(validate.errors[1].field, 'data["x"]')
   t.strictEqual(validate.errors[1].message, 'is the wrong type')
   t.notOk(validate({x: 'string', y: 'value'}), 'should be invalid')
   t.strictEqual(validate.errors.length, 1);
-  t.strictEqual(validate.errors[0].field, 'data.x')
+  t.strictEqual(validate.errors[0].field, 'data["x"]')
   t.strictEqual(validate.errors[0].message, 'is the wrong type')
   t.ok(validate({x: 1, y: 'value'}), 'should be invalid')
   t.end();
@@ -415,7 +415,7 @@ tape('nested required array decl', function(t) {
 
   t.ok(validate({x: {}}), 'should be valid')
   t.notOk(validate({}), 'should not be valid')
-  t.strictEqual(validate.errors[0].field, 'data.x', 'should output the missing field')
+  t.strictEqual(validate.errors[0].field, 'data["x"]', 'should output the missing field')
   t.end()
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -541,13 +541,6 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  integrity sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
-  dependencies:
-    is-property "^1.0.0"
-
 get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
@@ -678,11 +671,6 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
-  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
 is-regex@^1.0.4, is-regex@^1.0.5, is-regex@~1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Always use` JSON.stringify` for path parts instead, with `[]` access.

Reasons:
 * this code is used for security purposes
 * `is-property` is too complex (git history also hints past bugs, including a false positive, which also fits the version range requested here btw)
 * the performance benefit of using short form is negligible, if present, on a modern js engine