### PR TITLE
drop .error support

### DIFF
--- a/index.js
+++ b/index.js
@@ -611,14 +611,8 @@ const compile = function(schema, cache, root, reporter, opts) {
   validateScope(fun.makeRawSource(), scope)
 
   const validate = fun.makeFunction(scope)
-  validate.toModule = function() {
-    return fun.makeModule(scope)
-  }
-
-  validate.toJSON = function() {
-    return schema
-  }
-
+  validate.toModule = () => fun.makeModule(scope)
+  validate.toJSON = () => schema
   return validate
 }
 

--- a/index.js
+++ b/index.js
@@ -614,20 +614,6 @@ const compile = function(schema, cache, root, reporter, opts) {
   validate.toModule = function() {
     return fun.makeModule(scope)
   }
-  validate.errors = null
-
-  if (Object.defineProperty) {
-    Object.defineProperty(validate, 'error', {
-      get: function() {
-        if (!validate.errors) return ''
-        return validate.errors
-          .map(function(err) {
-            return `${err.field} ${err.message}`
-          })
-          .join('\n')
-      },
-    })
-  }
 
   validate.toJSON = function() {
     return schema


### PR DESCRIPTION
It was broken in 'toModule' variant.
Also, no tests rely on it.

`validate.errors = null` also wasn't really meaningful, let that just be `undefined` until the first run.

Also, some arrow functions.
