### PR TITLE
fix dependencies processing

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,11 +319,12 @@ const compile = function(schema, cache, root, reporter, opts) {
           )
           error('dependencies not set')
           fun.write('}')
-        }
-        if (typeof deps === 'object') {
+        } else if (typeof deps === 'object') {
           fun.write('if (%s !== undefined) {', genobj(name, key))
           visit(name, deps, reporter, filter, schemaPath.concat(['dependencies', key]))
           fun.write('}')
+        } else {
+          throw new Error('Unexpected dependencies entry')
         }
       }
 


### PR DESCRIPTION
Also add a safeguard.

Before this, in case if `deps` is an array, both code paths fired, e.g. on:
```json
{
  "dependencies": {"bar": ["foo"]}
}
```