### PR TITLE
add support for bool schema from draft6

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,29 @@ const compile = function(schema, cache, root, reporter, opts) {
   fun.write('var errors = 0')
 
   const visit = function(name, node, reporter, filter, schemaPath) {
+    const error = function(msg, prop, value) {
+      fun.write('errors++')
+      if (reporter === true) {
+        fun.write('if (validate.errors === null) validate.errors = []')
+        if (verbose) {
+          fun.write(
+            'validate.errors.push({field:%s,message:%s,value:%s,type:%s,schemaPath:%s})',
+            formatName(prop || name),
+            JSON.stringify(msg),
+            value || name,
+            JSON.stringify(type),
+            JSON.stringify(schemaPath)
+          )
+        } else {
+          fun.write(
+            'validate.errors.push({field:%s,message:%s})',
+            formatName(prop || name),
+            JSON.stringify(msg)
+          )
+        }
+      }
+    }
+
     if (node.constructor.toString() === Object.toString()) {
       for (const keyword of Object.keys(node)) {
         if (!KNOWN_KEYWORDS.includes(keyword)) {
@@ -182,28 +205,6 @@ const compile = function(schema, cache, root, reporter, opts) {
     }
 
     let indent = 0
-    const error = function(msg, prop, value) {
-      fun.write('errors++')
-      if (reporter === true) {
-        fun.write('if (validate.errors === null) validate.errors = []')
-        if (verbose) {
-          fun.write(
-            'validate.errors.push({field:%s,message:%s,value:%s,type:%s,schemaPath:%s})',
-            formatName(prop || name),
-            JSON.stringify(msg),
-            value || name,
-            JSON.stringify(type),
-            JSON.stringify(schemaPath)
-          )
-        } else {
-          fun.write(
-            'validate.errors.push({field:%s,message:%s})',
-            formatName(prop || name),
-            JSON.stringify(msg)
-          )
-        }
-      }
-    }
 
     if (node.default !== undefined) {
       indent++

--- a/index.js
+++ b/index.js
@@ -168,6 +168,18 @@ const compile = function(schema, cache, root, reporter, opts) {
       }
     }
 
+    if (typeof node === 'boolean') {
+      if (node === true) {
+        // any is valid
+        // TODO: don't allow in strong mode
+      } else { // node === false
+        fun.write('if (%s !== undefined) {', name)
+        error('is unexpected')
+        fun.write('}')
+      }
+      return
+    }
+
     if (node.constructor.toString() === Object.toString()) {
       for (const keyword of Object.keys(node)) {
         if (!KNOWN_KEYWORDS.includes(keyword)) {


### PR DESCRIPTION
error() function is just moved upwards as it's used earlier.

No support for bool schemas in .items yet, but this already makes a bunch of new tests from draft6 pass (can be tested with #20 + `s/draft4/draft6/`).