### PR TITLE
fix boolean 'not' schema from draft6

### DIFF
--- a/index.js
+++ b/index.js
@@ -464,7 +464,7 @@ const compile = function(schema, cache, root, reporter, opts) {
       consume('$ref')
     }
 
-    if (node.not) {
+    if (node.not || node.not === false) {
       const prev = gensym('prev')
       fun.write('var %s = errors', prev)
       visit(name, node.not, false, filter, schemaPath.concat('not'))


### PR DESCRIPTION
File: `not.json`
Block: `not with boolean schema false`

This is basically #21 in sub-schemas, and ensures we follow that code path in `not: false`cases.