### PR TITLE
whitelist definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,6 +212,13 @@ const compile = function(schema, root, reporter, opts, scope) {
     }
     if (type) consume('type') // checked below after overwrites
 
+    // defining defs are allowed, those are validated on usage
+    if (typeof node.$defs === 'object') {
+      consume('$defs')
+    } else if (typeof node.definitions === 'object') {
+      consume('definitions')
+    }
+
     const validateTypeApplicable = (...types) => {
       if (!type) return // no type enforced
       if (typeof type === 'string') {

--- a/known-keywords.js
+++ b/known-keywords.js
@@ -30,4 +30,6 @@ module.exports = [
   'uniqueItems',
   '$ref',
   'default',
+  'definitions', // up to draft7
+  '$defs', // since draft2019-09
 ]

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -13,7 +13,6 @@ const unsupported = new Set([
   // Blocks
   'format.json/validation of IP addresses',
   'format.json/validation of IPv6 addresses',
-  'items.json/items and subitems',
   // Specific tests
   'items.json/an array of schemas for items/JavaScript pseudo-array is valid',
 ])


### PR DESCRIPTION
Support specifying `definitions` or `$defs`.

Those should be validated on usage.