### PR TITLE
Remove "tuple" logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -469,19 +469,6 @@ const compile = function(schema, root, reporter, opts, scope) {
       consume('not')
     }
 
-    if (node.items && !Array.isArray(node.items)) {
-      validateTypeApplicable('array')
-      if (type !== 'array') fun.write('if (%s) {', types.array(name))
-
-      const i = genloop()
-      fun.write('for (var %s = 0; %s < %s.length; %s++) {', i, i, name, i)
-      visit(`${name}[${i}]`, node.items, reporter, schemaPath.concat('items'))
-      fun.write('}')
-
-      if (type !== 'array') fun.write('}')
-      consume('items')
-    }
-
     if (node.patternProperties) {
       validateTypeApplicable('object')
       if (type !== 'object') fun.write('if (%s) {', types.object(name))
@@ -708,7 +695,19 @@ const compile = function(schema, root, reporter, opts, scope) {
         if (Array.isArray(type) && type.indexOf('null') !== -1) fun.write('}')
       }
       consume('items')
+    } else if (node.items) {
+      validateTypeApplicable('array')
+      if (type !== 'array') fun.write('if (%s) {', types.array(name))
+
+      const i = genloop()
+      fun.write('for (var %s = 0; %s < %s.length; %s++) {', i, i, name, i)
+      visit(`${name}[${i}]`, node.items, reporter, schemaPath.concat('items'))
+      fun.write('}')
+
+      if (type !== 'array') fun.write('}')
+      consume('items')
     }
+
     if (typeof node.properties === 'object') {
       validateTypeApplicable('object')
       for (const p of Object.keys(node.properties)) {

--- a/index.js
+++ b/index.js
@@ -685,6 +685,8 @@ const compile = function(schema, root, reporter, opts, scope) {
     }
 
     if (Array.isArray(node.items)) {
+      validateTypeApplicable('array')
+      if (type !== 'array') fun.write('if (%s) {', types.array(name))
       const properties = { ...node.items }
       for (const p of Object.keys(properties)) {
         if (Array.isArray(type) && type.indexOf('null') !== -1)
@@ -694,6 +696,7 @@ const compile = function(schema, root, reporter, opts, scope) {
 
         if (Array.isArray(type) && type.indexOf('null') !== -1) fun.write('}')
       }
+      if (type !== 'array') fun.write('}')
       consume('items')
     } else if (node.items) {
       validateTypeApplicable('array')

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -13,8 +13,6 @@ const unsupported = new Set([
   // Blocks
   'format.json/validation of IP addresses',
   'format.json/validation of IPv6 addresses',
-  // Specific tests
-  'items.json/an array of schemas for items/JavaScript pseudo-array is valid',
 ])
 
 const schemaDir = path.join(__dirname, '/json-schema/draft4')


### PR DESCRIPTION
Per tests, `.items` checks apply only to arrays and the type shouldn't be forced to an array automatically if `.items` are present.

Instead, schemas should specify `type: "array"` to enforce array type, or any non-array value would pass `.items` check on other validators.

We will have an option to force `type` being present (#28), but specifying `.items` is not a way around it.

Fixes a testcase.

Also some cleanup is done here, perhaps best reviewed per-commit if too complex.