### PR TITLE
'const' support (draft6 and later), deep equality for enums

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,13 +369,13 @@ const compile = function(schema, cache, root, reporter, opts) {
       consume('uniqueItems')
     }
 
-    const makeCompare = (name, complex) =>
-      complex
-        ? (e) => {
-            scope.deepEqual = deepEqual
-            return `!deepEqual(${name}, ${JSON.stringify(e)})`
-          }
-        : (e) => `${name} !== ${JSON.stringify(e)}`
+    const makeCompare = (name, complex) => {
+      if (complex) {
+        scope.deepEqual = deepEqual
+        return (e) => `!deepEqual(${name}, ${JSON.stringify(e)})`
+      }
+      return (e) => `${name} !== ${JSON.stringify(e)}`
+    }
 
     if (node.const !== undefined) {
       const complex = typeof node.const === 'object'

--- a/known-keywords.js
+++ b/known-keywords.js
@@ -27,6 +27,7 @@ module.exports = [
   'patternProperties',
   'dependencies',
   'enum',
+  'const',
   'uniqueItems',
   '$ref',
   'default',


### PR DESCRIPTION
Tests in #26.

There are no tests for deep equality on enums to ignore keys order, but that matches `const` tests and that's how ajv works with enums.