### PR TITLE
drop filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,24 +85,6 @@ validate('hello') // returns true
 validate(42) // return false
 ```
 
-## Filtering away additional properties
-
-is-my-json-valid supports filtering away properties not in the schema
-
-```js
-var filter = validator.filter({
-  required: true,
-  type: 'object',
-  properties: {
-    hello: {type: 'string', required: true}
-  },
-  additionalProperties: false
-})
-
-var doc = {hello: 'world', notInSchema: true}
-console.log(filter(doc)) // {hello: 'world'}
-```
-
 ## Verbose mode shows more information about the source of the error
 
 When the `verbose` options is set to `true`, `is-my-json-valid` also outputs:


### PR DESCRIPTION
It was unreliable, filtered away only additional properties (did not even support filtering additional items) and hid validation errors.

Also mutation of input objects is not a good practice, that is not a way to create sanitized objects.

Also, filter had 0 test coverage - no tests depended on filtering.

Error message is added to keep errors in drop-in replacements visible.

---

Example from the readme: https://github.com/ExodusMovement/is-my-json-valid/blob/f4d6e88d6aedf173486cc9aea438744ea2a65262/README.md#L88-L104

```js
var filter = validator.filter({
  required: true,
  type: 'object',
  properties: {
    hello: {type: 'string', required: true}
  },
  additionalProperties: false
})

var doc = {hello: 'world', notInSchema: true}
console.log(filter(doc)) // {hello: 'world'}

const evil = { hello: { whatever: "boo" } }
console.log(filter(evil)) // does not filter anything, no way to detect failure
```