### PR TITLE
refs/id/description fixes, part 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const genobj = (name, property) => {
   return `${name}[${JSON.stringify(property)}]`
 }
 
-const get = function(obj, additionalSchemas, ptr) {
+const resolveReference = (obj, additionalSchemas, ptr) => {
   const visit = function(sub) {
     if (sub && (sub.id || sub.$id) === ptr) return sub
     if (typeof sub !== 'object' || !sub) return null
@@ -468,7 +468,7 @@ const compile = function(schema, root, reporter, opts, scope) {
     }
 
     if (node.$ref) {
-      const sub = get(root, (opts && opts.schemas) || {}, node.$ref)
+      const sub = resolveReference(root, (opts && opts.schemas) || {}, node.$ref)
       if (sub) {
         let n = refCache.get(node.$ref)
         if (!n) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const genobj = (name, property) => {
   return `${name}[${JSON.stringify(property)}]`
 }
 
-const resolveReference = (obj, additionalSchemas, ptr) => {
+const resolveReference = (root, additionalSchemas, ptr) => {
   const visit = function(sub) {
     if (sub && (sub.id || sub.$id) === ptr) return sub
     if (typeof sub !== 'object' || !sub) return null
@@ -19,14 +19,14 @@ const resolveReference = (obj, additionalSchemas, ptr) => {
     }, null)
   }
 
-  const res = visit(obj)
+  const res = visit(root)
   if (res) return res
 
   ptr = ptr.replace(/^#/, '')
   ptr = ptr.replace(/\/$/, '')
 
   try {
-    return jsonpointer.get(obj, decodeURI(ptr))
+    return jsonpointer.get(root, decodeURI(ptr))
   } catch (err) {
     const end = ptr.indexOf('#')
     let other

--- a/index.js
+++ b/index.js
@@ -479,6 +479,8 @@ const compile = function(schema, root, reporter, opts, scope) {
         fun.write('if (!(%s(%s))) {', n, name)
         error('referenced schema does not match')
         fun.write('}')
+      } else {
+        throw new Error(`ref not found: ${node.$ref}`)
       }
       consume('$ref')
     }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const genobj = (name, property) => {
 
 const get = function(obj, additionalSchemas, ptr) {
   const visit = function(sub) {
-    if (sub && sub.id === ptr) return sub
+    if (sub && (sub.id || sub.$id) === ptr) return sub
     if (typeof sub !== 'object' || !sub) return null
     return Object.keys(sub).reduce(function(res, k) {
       return res || visit(sub[k])
@@ -226,11 +226,18 @@ const compile = function(schema, root, reporter, opts, scope) {
       unprocessed.delete(property)
     }
 
+    if (typeof node.description === 'string') consume('description') // unused, meta-only
     // defining defs are allowed, those are validated on usage
     if (typeof node.$defs === 'object') {
       consume('$defs')
     } else if (typeof node.definitions === 'object') {
       consume('definitions')
+    }
+    // same for id
+    if (typeof node.$id === 'string') {
+      consume('$id')
+    } else if (typeof node.id === 'string') {
+      consume('id')
     }
 
     let indent = 0

--- a/known-keywords.js
+++ b/known-keywords.js
@@ -1,6 +1,7 @@
 module.exports = [
   'items',
-  'id',
+  'id', // up to draft4
+  '$id', // since draft6
   'type',
   'not',
   'properties',


### PR DESCRIPTION
* allow descriptions (not supposed to be used for validation, only meta)
* allow `id`/`$id` (used only for resolving refs)
* don't fail open when ref failed to resolve, instead throw an error
  Before this change, it could have reported succeeded validation instead of failing there.
* rename `get()` -> `resolveReference()` for clarity