### PR TITLE
refs fixes, part 3: resolve cyclic dependencies in refs

### DIFF
--- a/index.js
+++ b/index.js
@@ -474,7 +474,10 @@ const compile = function(schema, root, reporter, opts, scope) {
         if (!n) {
           n = gensym('ref')
           refCache.set(node.$ref, n)
-          scope[n] = compile(sub, root, false, opts, scope)
+          let fn = null // resolve cyclic dependencies
+          scope[n] = (...args) => fn(...args)
+          fn = compile(sub, root, false, opts, scope)
+          scope[n] = fn
         }
         fun.write('if (!(%s(%s))) {', n, name)
         error('referenced schema does not match')


### PR DESCRIPTION
Instead of #41.

Fixes some tests from `refs.json` in non-`toModule` mode.

The problem was that `toFunction` binding to the scope is early and done after `compile()` which is called per-ref -- that fixates the scope state at the moment of function compilation (as opposed to module, which fixates the scope on manual `toModule` call).

As a result, if functions are not in scope at the time of their construction, they are not reachable by their scope name from themselves and from their subdeps.

This fixes that by adding a wrapping placeholder ahead of time to the scope.
It has to be rewritten with the actual function because otherwise `toModule` would be broken -- it won't work with those placeholders.
