### PR TITLE
Whitelist keywords: $schema, description, $comment, examples

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,12 @@ const compile = function(schema, root, reporter, opts, scope) {
       if (!schemaVersions.includes(node.$schema)) throw new Error('Unexpected schema version')
       consume('$schema') // meta-only
     }
+
     if (typeof node.description === 'string') consume('description') // unused, meta-only
+    if (typeof node.title === 'string') consume('title') // unused, meta-only
+    if (typeof node.$comment === 'string') consume('$comment') // unused, meta-only
+    if (Array.isArray(node.examples)) consume('examples') // unused, meta-only
+
     // defining defs are allowed, those are validated on usage
     if (typeof node.$defs === 'object') {
       consume('$defs')

--- a/index.js
+++ b/index.js
@@ -133,6 +133,14 @@ const stringLength = (string) => [...string].length
 const scopeSyms = Symbol('syms')
 const scopeRefCache = Symbol('refcache')
 
+const schemaVersions = [
+  'http://json-schema.org/draft/2019-09/schema#',
+  'http://json-schema.org/draft-07/schema#',
+  'http://json-schema.org/draft-06/schema#',
+  'http://json-schema.org/draft-04/schema#',
+  'http://json-schema.org/draft-03/schema#',
+]
+
 const compile = function(schema, root, reporter, opts, scope) {
   const fmts = opts ? Object.assign({}, formats, opts.formats) : formats
   const verbose = opts ? !!opts.verbose : false
@@ -223,6 +231,10 @@ const compile = function(schema, root, reporter, opts, scope) {
       unprocessed.delete(property)
     }
 
+    if (node === root && typeof node.$schema === 'string') {
+      if (!schemaVersions.includes(node.$schema)) throw new Error('Unexpected schema version')
+      consume('$schema') // meta-only
+    }
     if (typeof node.description === 'string') consume('description') // unused, meta-only
     // defining defs are allowed, those are validated on usage
     if (typeof node.$defs === 'object') {

--- a/index.js
+++ b/index.js
@@ -211,12 +211,9 @@ const compile = function(schema, root, reporter, opts, scope) {
       return
     }
 
-    if (node.constructor.toString() === Object.toString()) {
-      for (const keyword of Object.keys(node)) {
-        if (!KNOWN_KEYWORDS.includes(keyword)) {
-          throw new Error(`Keyword not supported: ${keyword}`)
-        }
-      }
+    if (Object.getPrototypeOf(node) !== Object.prototype) throw new Error('Schema is not an object')
+    for (const keyword of Object.keys(node)) {
+      if (!KNOWN_KEYWORDS.includes(keyword)) throw new Error(`Keyword not supported: ${keyword}`)
     }
 
     const unprocessed = new Set(Object.keys(node))

--- a/known-keywords.js
+++ b/known-keywords.js
@@ -8,7 +8,6 @@ module.exports = [
   'properties',
   'additionalItems',
   'additionalProperties',
-  'description',
   'format',
   'required',
   'allOf',
@@ -36,4 +35,11 @@ module.exports = [
   'default',
   'definitions', // up to draft7
   '$defs', // since draft2019-09
+
+  // Unused meta keywords not affecting validation (annotations and comments)
+  // https://json-schema.org/understanding-json-schema/reference/generic.html
+  'description',
+  'title',
+  'examples',
+  '$comment',
 ]

--- a/known-keywords.js
+++ b/known-keywords.js
@@ -1,4 +1,5 @@
 module.exports = [
+  '$schema',
   'items',
   'id', // up to draft4
   '$id', // since draft6


### PR DESCRIPTION
* Add a check for schema to be an object (if it's not boolean)
* `$schema` keyword support added.
* `description`/`$comment`/`examples` whitelisted