### PR TITLE
required array is only applicable on objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,6 +335,7 @@ const compile = function(schema, root, reporter, opts, scope) {
     }
 
     if (Array.isArray(node.required)) {
+      validateTypeApplicable('object')
       const checkRequired = function(req) {
         const prop = genobj(name, req)
         fun.write('if (%s === undefined) {', prop)
@@ -342,10 +343,10 @@ const compile = function(schema, root, reporter, opts, scope) {
         fun.write('missing++')
         fun.write('}')
       }
-      fun.write('if ((%s)) {', type !== 'object' ? types.object(name) : 'true')
+      if (type !== 'object') fun.write('if (%s) {', types.object(name))
       fun.write('var missing = 0')
       node.required.map(checkRequired)
-      fun.write('}')
+      if (type !== 'object') fun.write('}')
       if (!greedy) {
         fun.write('if (missing === 0) {')
         indent++

--- a/index.js
+++ b/index.js
@@ -336,19 +336,20 @@ const compile = function(schema, root, reporter, opts, scope) {
 
     if (Array.isArray(node.required)) {
       validateTypeApplicable('object')
+      const missing = gensym('missing')
       const checkRequired = function(req) {
         const prop = genobj(name, req)
         fun.write('if (%s === undefined) {', prop)
         error('is required', prop)
-        fun.write('missing++')
+        fun.write('%s++', missing)
         fun.write('}')
       }
       if (type !== 'object') fun.write('if (%s) {', types.object(name))
-      fun.write('var missing = 0')
+      fun.write('var %s = 0', missing)
       node.required.map(checkRequired)
       if (type !== 'object') fun.write('}')
       if (!greedy) {
-        fun.write('if (missing === 0) {')
+        fun.write('if (%s === 0) {', missing)
         indent++
       }
       consume('required')


### PR DESCRIPTION
Ensure it's not present on nodes that can't be objects.

Also ensure no conflicts on `missing` variable name.