### PR TITLE
implement parser (defaults to strong mode)

### DIFF
--- a/index.js
+++ b/index.js
@@ -904,7 +904,33 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
   return validate
 }
 
-module.exports = function(schema, opts = {}) {
+const validator = function(schema, opts = {}) {
   if (typeof schema === 'string') schema = JSON.parse(schema)
   return compile(schema, schema, true, opts)
 }
+
+const parser = function(schema, opts = {}) {
+  // strong mode is default in parser
+  const validate = validator(schema, { mode: 'strong', ...opts })
+  const parse = (src) => {
+    if (typeof src !== 'string') throw new Error('Invalid type!')
+    const data = JSON.parse(src)
+    if (validate(data)) return data
+    const message = validate.errors
+      ? validate.errors.map((err) => `${err.field} ${err.message}`).join('\n')
+      : ''
+    throw new Error(`JSON validation error${message ? `: ${message}` : ''}`)
+  }
+  parse.toModule = () =>
+    [
+      '(function(src) {',
+      `const validate = ${validate.toModule()}`,
+      `const parse = ${parse}\n`,
+      'return parse(src)',
+      '});',
+    ].join('\n')
+  return parse
+}
+
+module.exports = validator
+Object.assign(module.exports, { validator, parser })

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,0 +1,42 @@
+const tape = require('tape')
+const { validator, parser } = require('../')
+
+tape('exports', (t) => {
+  t.strictEqual(typeof validator, 'function', 'validator is a function')
+  t.strictEqual(typeof parser, 'function', 'parser is a function')
+  t.end()
+})
+
+tape('default is strong mode', (t) => {
+  t.throws(() => {
+    parser({})
+  }, /\[requireValidation\]/)
+
+  t.throws(() => {
+    parser({}, { requireValidation: false })
+  }, /Strong mode demands requireValidation/)
+
+  t.doesNotThrow(() => {
+    parser({}, { mode: 'default' })
+  })
+
+  t.end()
+})
+
+tape('parser works correctly', (t) => {
+  let parsed
+
+  t.strictEqual(typeof parser({ type: 'string' }), 'function', 'returns a function')
+
+  t.throws(() => {
+    parser({ type: 'integer' })('{}')
+  }, /validation error/)
+
+  t.doesNotThrow(() => {
+    parsed = parser({ type: 'integer' })('10')
+  })
+
+  t.strictEqual(parsed, 10, 'result returned correctly')
+
+  t.end()
+})


### PR DESCRIPTION
Depends on #28, otherwise ready.

The idea is to use exclusively the provided parser API to generate parsers instead of validators, so that we will validate at parse time immediately and throw errors if validation fails.

That way:
* we can ensure that untrusted parsed object is not used anywhere before it's validated
* we can ensure that we are always using the validator with secure parameters (aka strong mode from #28 and no unwanted options, perhaps more schema checks a bit later)