### PR TITLE
Deduplicate identical formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,7 @@ const stringLength = (string) => [...string].length
 
 const scopeSyms = Symbol('syms')
 const scopeRefCache = Symbol('refcache')
+const scopeFormatCache = Symbol('formatcache')
 
 const compile = function(schema, root, reporter, opts, scope) {
   const fmts = opts ? Object.assign({}, formats, opts.formats) : formats
@@ -142,6 +143,8 @@ const compile = function(schema, root, reporter, opts, scope) {
   if (!scope) scope = Object.create(null)
   if (!scope[scopeRefCache]) scope[scopeRefCache] = new Map()
   const refCache = scope[scopeRefCache]
+  if (!scope[scopeFormatCache]) scope[scopeFormatCache] = new Map()
+  const formatCache = scope[scopeFormatCache]
   if (!scope[scopeSyms]) scope[scopeSyms] = new Map()
   const syms = scope[scopeSyms]
   const gensym = (name) => {
@@ -318,9 +321,13 @@ const compile = function(schema, root, reporter, opts, scope) {
       if (type !== 'string' && formats[node.format]) fun.write('if (%s) {', types.string(name))
       const format = fmts[node.format]
       if (format instanceof RegExp || typeof format === 'function') {
+        let n = formatCache.get(format)
+        if (!n) {
+          n = gensym('format')
+          scope[n] = format
+          formatCache.set(format, n)
+        }
         const condition = format instanceof RegExp ? '!%s.test(%s)' : '!%s(%s)'
-        const n = gensym('format')
-        scope[n] = format
         fun.write(`if (${condition}) {`, n, name)
         error(`must be ${node.format} format`)
         fun.write('}')


### PR DESCRIPTION
Otherwise formats are copied to scope one for each usage, not for format.
They have no state that we use, so it's ok to deduplicate them and use exactly one scope var per each unique format used.