### PR TITLE
Don't apply defaults by default, add 'applyDefault' opt-in

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,10 +243,12 @@ const compile = function(schema, root, reporter, opts, scope) {
     let indent = 0
 
     if (node.default !== undefined) {
-      indent++
-      fun.write('if (%s === undefined) {', name)
-      fun.write('%s = %s', name, jaystring(node.default))
-      fun.write('} else {')
+      if (opts.applyDefault) {
+        indent++
+        fun.write('if (%s === undefined) {', name)
+        fun.write('%s = %s', name, jaystring(node.default))
+        fun.write('} else {')
+      }
       consume('default')
     }
 
@@ -764,7 +766,7 @@ const compile = function(schema, root, reporter, opts, scope) {
   return validate
 }
 
-module.exports = function(schema, opts) {
+module.exports = function(schema, opts = {}) {
   if (typeof schema === 'string') schema = JSON.parse(schema)
   return compile(schema, schema, true, opts)
 }


### PR DESCRIPTION
Property name matches ajv.

We don't want `.validate` to have side-effects without an explicit opt in.