### PR TITLE
Embed jaystring, drop .toJayString support

### DIFF
--- a/generate-function.js
+++ b/generate-function.js
@@ -1,5 +1,5 @@
 const { format: utilFormat } = require('util')
-const jaystring = require('jaystring')
+const jaystring = require('./jaystring')
 
 const INDENT_START = /[{[]/
 const INDENT_END = /[}\]]/

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const jaystring = require('jaystring')
+const jaystring = require('./jaystring')
 const genfun = require('./generate-function')
 const { resolveReference } = require('./pointer')
 const formats = require('./formats')

--- a/jaystring.js
+++ b/jaystring.js
@@ -1,0 +1,51 @@
+const isArrowFnWithParensRegex = /^\([^)]*\) *=>/
+const isArrowFnWithoutParensRegex = /^[^=]*=>/
+
+const stringify = {
+  string: (s) => JSON.stringify(s),
+  number: (n) => String(n),
+  boolean: (b) => String(b),
+  undefined: () => 'undefined',
+  array: (array) => `[${array.map(jaystring).join(',')}]`,
+  date: (date) => `new Date(${date.getTime()})`,
+
+  function: (func) => {
+    if (Object.getPrototypeOf(func) !== Function.prototype)
+      throw new Error('Can not stringify a function with unexpected prototype')
+
+    const stringified = func.toString()
+    if (func.prototype) return stringified // normal function
+    if (isArrowFnWithParensRegex.test(stringified) || isArrowFnWithoutParensRegex.test(stringified))
+      return stringified // Arrow function
+
+    // Shortened ES6 object method declaration
+    return `function ${stringified}`
+  },
+
+  object: (obj) => {
+    if (obj === null) return 'null'
+    const proto = Object.getPrototypeOf(obj)
+
+    if (Array.isArray(obj) && proto === Array.prototype) return stringify.array(obj)
+    if (obj instanceof Date && proto === Date.prototype) return stringify.date(obj)
+    if (obj instanceof RegExp && proto === RegExp.prototype) return String(obj)
+
+    if (proto === Object.prototype || proto === null) {
+      const parts = Object.entries(obj)
+      return `{${parts.map(([key, val]) => `${JSON.stringify(key)}:${jaystring(val)}`).join(',')}}`
+    }
+
+    throw new Error('Can not stringify an object with unexpected prototype')
+  },
+
+  symbol: (symbol) => `Symbol(${JSON.stringify(symbol.description)})`,
+}
+
+function jaystring(item) {
+  const type = typeof item
+  const toString = stringify.hasOwnProperty(type) ? stringify[type] : null
+  if (!toString) throw new Error(`Cannot stringify ${item} - unknown type ${typeof item}`)
+  return toString(item)
+}
+
+module.exports = jaystring

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "github.com/ExodusMovement/is-my-json-valid",
   "files": [
     "generate-function.js",
+    "jaystring.js",
     "formats.js",
     "known-keywords.js",
     "pointer.js",
@@ -19,7 +20,6 @@
     "test:normal": "tape test/*.js"
   },
   "dependencies": {
-    "jaystring": "^1.0.6"
   },
   "devDependencies": {
     "eslint": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,11 +757,6 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-jaystring@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/jaystring/-/jaystring-1.0.6.tgz#0481dda66ab99d6ba6d02a6909b83c0a4c4442f5"
-  integrity sha512-Jf/vf1llT5eBwT60UUQbo+JClLTXx20G6A9L9L+gpZQE6rBmDw5wBmhj2qBRsfNAIZ01euaBmyEXlWh/yqxHLg==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
`toJayString` should have been a Symbol, but we don't even use that.

Also add more safeguards in object/function stringification.

0 deps now!