### PR TITLE
Better options handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     greedy = false,
     applyDefault = false,
     allErrors: optAllErrors = false,
+    dryRun = false,
     $schemaDefault = null,
     formats: optFormats = {},
     schemas = {},
@@ -890,6 +891,8 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
 
   fun.write('return errors === 0')
   fun.write('}')
+
+  if (dryRun) return
 
   const validate = fun.makeFunction(scope)
   validate.toModule = () => fun.makeModule(scope)

--- a/test-module.js
+++ b/test-module.js
@@ -12,6 +12,7 @@ if (validator !== indexModule.exports) throw new Error('Unexpected!')
 
 indexModule.exports = function(...args) {
   const validate = validator(...args)
+  if (!validate) return validate
   // eslint-disable-next-line no-new-func
   const wrapped = new Function(`return ${validate.toModule()}`)()
   wrapped.toModule = (...args) => validate.toModule(...args)

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,9 @@
+const tape = require('tape')
+const validator = require('../')
+
+tape('dryRun', (t) => {
+  t.strictEqual(typeof validator({}), 'function', 'normal usage returns a function')
+  t.strictEqual(typeof validator({}, { dryRun: false }), 'function', '!dryRun returns a function')
+  t.strictEqual(typeof validator({}, { dryRun: true }), 'undefined', 'dryRun returns undefined')
+  t.end()
+})


### PR DESCRIPTION
1.    Cleanup options parsing, throw on unknown options
2.    Implement dryRun option, to use in schema checks
    It doesn't pass the constructed code to a new Function(), just returns.
3.    More semantic and fine-grained options for strong/lax modes
    The modes are still kept for simplicity, an opt-in for the secure config must be trivial.
