### PR TITLE
Fix tap-spec usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "prettier --list-different '**/*.js'&& eslint .",
     "format": "prettier --write '**/*.js'",
-    "test": "npm run test:raw | tap-spec",
+    "test": "npm run test:normal | tap-spec && npm run test:module | tap-spec",
     "test:raw": "npm run test:normal && npm run test:module",
     "test:module": "tape -r ./test-module.js test/*.js",
     "test:normal": "tape test/*.js"


### PR DESCRIPTION
tape output can't be concatenated like that, it hides the exit code of the second (module) variant.

This hides the total number of tests (actually, outputs separately the first half and the second half), but it looks to be the lesser of two evils here.