### PR TITLE
Error fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,8 +211,8 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       enforce(KNOWN_KEYWORDS.includes(key) || allowUnusedKeywords, 'Keyword not supported:', key)
 
     const unused = new Set(Object.keys(node))
-    const consume = (property, required = true) => {
-      enforce(unused.has(property) || !required, 'Unexpected double consumption:', property)
+    const consume = (property) => {
+      enforce(unused.has(property), 'Unexpected double consumption:', property)
       unused.delete(property)
     }
 

--- a/index.js
+++ b/index.js
@@ -173,8 +173,8 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       if (!allErrors) fun.write('return false')
     }
 
-    const fail = (msg, value = '') => {
-      const comment = value && ` ${JSON.stringify(value)}`
+    const fail = (msg, value) => {
+      const comment = value !== undefined ? ` ${JSON.stringify(value)}` : ''
       throw new Error(`${msg}${comment} at #${toPointer(schemaPath)}`)
     }
     const enforce = (ok, ...args) => ok || fail(...args)

--- a/index.js
+++ b/index.js
@@ -10,15 +10,6 @@ const genobj = (name, property) => {
   return `${name}[${JSON.stringify(property)}]`
 }
 
-const formatName = function(field) {
-  field = JSON.stringify(field)
-  // Commented out code from original vanilla version because it allows a code execution
-  // exploit from a maliciously crafted schema.
-  // var pattern = /\[([^\[\]"]+)\]/
-  // while (pattern.test(field)) field = field.replace(pattern, '."+$1+"')
-  return field
-}
-
 const types = {}
 types.any = () => 'true'
 types.null = (name) => `${name} === null`
@@ -169,7 +160,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
         if (verbose) {
           fun.write(
             'validate.errors.push({field:%s,message:%s,value:%s,type:%s,schemaPath:%s})',
-            formatName(prop || name),
+            JSON.stringify(prop || name),
             JSON.stringify(msg),
             value || name,
             JSON.stringify(node.type || 'any'),
@@ -178,7 +169,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
         } else {
           fun.write(
             'validate.errors.push({field:%s,message:%s})',
-            formatName(prop || name),
+            JSON.stringify(prop || name),
             JSON.stringify(msg)
           )
         }

--- a/index.js
+++ b/index.js
@@ -178,12 +178,12 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       throw new Error(`${msg}${comment} at #${toPointer(schemaPath)}`)
     }
     const enforce = (ok, ...args) => ok || fail(...args)
-    const validationRequired = (msg) => enforce(!requireValidation, `[requireValidation] ${msg}`)
+    const enforceValidation = (msg) => enforce(!requireValidation, `[requireValidation] ${msg}`)
 
     if (typeof node === 'boolean') {
       if (node === true) {
         // any is valid
-        validationRequired('schema = true is not allowed')
+        enforceValidation('schema = true is not allowed')
       } else {
         // node === false
         fun.write('if (%s !== undefined) {', name)
@@ -300,14 +300,14 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     const { type } = node
-    if (!type) validationRequired('type is required')
+    if (!type) enforceValidation('type is required')
     if (type !== undefined && typeof type !== 'string' && !Array.isArray(type))
       fail('Unexpected type')
 
     const typeArray = type ? (Array.isArray(type) ? type : [type]) : []
     for (const t of typeArray) {
       enforce(typeof t === 'string' && types.hasOwnProperty(t), 'Unknown type:', t)
-      if (t === 'any') validationRequired('type = any is not allowed')
+      if (t === 'any') enforceValidation('type = any is not allowed')
     }
 
     const typeValidate = typeArray.map((t) => types[t](name)).join(' || ') || 'true'
@@ -354,7 +354,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     } else if (node.items.length === node.maxItems) {
       // No additional items are possible
     } else {
-      validationRequired('additionalItems rule must be specified for fixed arrays')
+      enforceValidation('additionalItems rule must be specified for fixed arrays')
     }
 
     if (node.format && fmts.hasOwnProperty(node.format)) {
@@ -509,7 +509,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       if (type !== 'object') fun.write('}')
       consume('additionalProperties')
     } else if (typeApplicable('object')) {
-      validationRequired('additionalProperties rule must be specified')
+      enforceValidation('additionalProperties rule must be specified')
     }
 
     if (typeof node.propertyNames === 'object' || typeof node.propertyNames === 'boolean') {
@@ -527,7 +527,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       consume('propertyNames')
     }
     if (typeof node.additionalProperties === 'object' && typeof node.propertyNames !== 'object') {
-      validationRequired('wild-card additionalProperties requires propertyNames')
+      enforceValidation('wild-card additionalProperties requires propertyNames')
     }
 
     if (node.not || node.not === false) {
@@ -802,7 +802,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       if (type !== 'array') fun.write('}')
       consume('items')
     } else if (typeApplicable('array')) {
-      validationRequired('items rule must be specified')
+      enforceValidation('items rule must be specified')
     }
 
     if (node.contains || node.contains === false) {

--- a/index.js
+++ b/index.js
@@ -186,10 +186,17 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       if (!allErrors) fun.write('return false')
     }
 
+    const fail = (msg, value) => {
+      const comment = value !== undefined ? ` ${JSON.stringify(value)}` : ''
+      throw new Error(`${msg}${comment} at #/${schemaPath.join('/')}`)
+    }
+    const enforce = (ok, ...args) => ok || fail(...args)
+    const validationRequired = (msg) => enforce(!requireValidation, `[requireValidation] ${msg}`)
+
     if (typeof node === 'boolean') {
       if (node === true) {
         // any is valid
-        if (requireValidation) throw new Error('[requireValidation] schema = true is not allowed')
+        validationRequired('schema = true is not allowed')
       } else {
         // node === false
         fun.write('if (%s !== undefined) {', name)
@@ -199,23 +206,19 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       return
     }
 
-    if (Object.getPrototypeOf(node) !== Object.prototype) throw new Error('Schema is not an object')
-    for (const keyword of Object.keys(node))
-      if (!KNOWN_KEYWORDS.includes(keyword) && !allowUnusedKeywords)
-        throw new Error(`Keyword not supported: ${keyword}`)
+    enforce(Object.getPrototypeOf(node) === Object.prototype, 'Schema is not an object')
+    for (const key of Object.keys(node))
+      enforce(KNOWN_KEYWORDS.includes(key) || allowUnusedKeywords, 'Keyword not supported:', key)
 
-    const unprocessed = new Set(Object.keys(node))
+    const unused = new Set(Object.keys(node))
     const consume = (property, required = true) => {
-      if (required && !unprocessed.has(property))
-        throw new Error(`Unexpected double consumption: ${property}`)
-      unprocessed.delete(property)
+      enforce(unused.has(property) || !required, 'Unexpected double consumption:', property)
+      unused.delete(property)
     }
 
     const finish = () => {
       while (indent--) fun.write('}')
-
-      if (!allowUnusedKeywords && unprocessed.size !== 0)
-        throw new Error(`Unprocessed keywords: ${[...unprocessed].join(', ')}`)
+      enforce(unused.size === 0 || allowUnusedKeywords, 'Unprocessed keywords:', [...unused])
     }
 
     if (node === root) {
@@ -226,7 +229,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       }
       if ($schema) {
         const version = $schema.replace(/^http:\/\//, 'https://').replace(/#$/, '')
-        if (!schemaVersions.includes(version)) throw new Error('Unexpected schema version')
+        enforce(schemaVersions.includes(version), 'Unexpected schema version:', version)
         rootMeta.set(root, {
           exclusiveRefs:
             // older than draft/2019-09
@@ -298,7 +301,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
         error('referenced schema does not match')
         fun.write('}')
       } else {
-        throw new Error(`failed to resolve $ref: ${node.$ref}`)
+        fail('failed to resolve $ref:', node.$ref)
       }
       consume('$ref')
 
@@ -310,17 +313,14 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     const { type } = node
-    if (requireValidation && !type) throw new Error('[requireValidation] type is required')
+    if (!type) validationRequired('type is required')
     if (type !== undefined && typeof type !== 'string' && !Array.isArray(type))
-      throw new Error('Unexpected type')
+      fail('Unexpected type')
 
     const typeArray = type ? (Array.isArray(type) ? type : [type]) : []
     for (const t of typeArray) {
-      if (typeof t !== 'string' || !types.hasOwnProperty(t)) {
-        throw new Error(`Unknown type: ${t}`)
-      }
-      if (requireValidation && t === 'any')
-        throw new Error('[requireValidation] type = any is not allowed')
+      enforce(typeof t === 'string' && types.hasOwnProperty(t), 'Unknown type:', t)
+      if (t === 'any') validationRequired('type = any is not allowed')
     }
 
     const typeValidate = typeArray.map((t) => types[t](name)).join(' || ') || 'true'
@@ -334,10 +334,8 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
 
     const typeApplicable = (...types) =>
       !type || typeArray.includes('any') || typeArray.some((x) => types.includes(x))
-    const validateTypeApplicable = (...types) => {
-      if (!typeApplicable(...types))
-        throw new Error(`Unexpected field in types: ${typeArray.join(', ')}`)
-    }
+    const validateTypeApplicable = (...types) =>
+      enforce(typeApplicable(...types), 'Unexpected field in type', type)
 
     if (!Array.isArray(node.items)) {
       // additionalItems is allowed, but ignored per some spec tests in this case!
@@ -368,8 +366,8 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       consume('additionalItems')
     } else if (node.items.length === node.maxItems) {
       // No additional items are possible
-    } else if (requireValidation) {
-      throw new Error('[requireValidation] additionalItems rule must be specified for fixed arrays')
+    } else {
+      validationRequired('additionalItems rule must be specified for fixed arrays')
     }
 
     if (node.format && fmts.hasOwnProperty(node.format)) {
@@ -393,8 +391,8 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
 
       if (type !== 'string' && formats[node.format]) fun.write('}')
       consume('format')
-    } else if (node.format) {
-      throw new Error(`Unrecognized format used: ${JSON.stringify(node.format)}`)
+    } else {
+      enforce(!node.format, 'Unrecognized format used:', node.format)
     }
 
     if (Array.isArray(node.required)) {
@@ -443,7 +441,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       fun.write('}')
       consume('const')
     } else if (node.enum) {
-      if (!Array.isArray(node.enum)) throw new Error('Invalid enum')
+      enforce(Array.isArray(node.enum), 'Invalid enum')
       const complex = node.enum.some((e) => typeof e === 'object')
       const compare = makeCompare(name, complex)
       fun.write('if (!(%s)) {', node.enum.map(compare).join(' || '))
@@ -473,7 +471,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
           visit(allErrors, name, deps, reporter, schemaPath.concat(['dependencies', key]))
           fun.write('}')
         } else {
-          throw new Error('Unexpected dependencies entry')
+          fail('Unexpected dependencies entry')
         }
       }
 
@@ -524,8 +522,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       if (type !== 'object') fun.write('}')
       consume('additionalProperties')
     } else if (typeApplicable('object')) {
-      if (requireValidation)
-        throw new Error('[requireValidation] additionalProperties rule must be specified')
+      validationRequired('additionalProperties rule must be specified')
     }
 
     if (typeof node.propertyNames === 'object' || typeof node.propertyNames === 'boolean') {
@@ -542,9 +539,8 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       if (type !== 'object') fun.write('}')
       consume('propertyNames')
     }
-    if (requireValidation) {
-      if (typeof node.additionalProperties === 'object' && typeof node.propertyNames !== 'object')
-        throw new Error('[requireValidation] wild-card additionalProperties requires propertyNames')
+    if (typeof node.additionalProperties === 'object' && typeof node.propertyNames !== 'object') {
+      validationRequired('wild-card additionalProperties requires propertyNames')
     }
 
     if (node.not || node.not === false) {
@@ -617,7 +613,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     if (node.allOf) {
-      if (!Array.isArray(node.allOf)) throw new Error('Invalid allOf')
+      enforce(Array.isArray(node.allOf), 'Invalid allOf')
       node.allOf.forEach(function(sch, key) {
         visit(allErrors, name, sch, reporter, schemaPath.concat(['allOf', key]))
       })
@@ -625,7 +621,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     if (node.anyOf && node.anyOf.length) {
-      if (!Array.isArray(node.anyOf)) throw new Error('Invalid anyOf')
+      enforce(Array.isArray(node.anyOf), 'Invalid anyOf')
       const prev = gensym('prev')
 
       node.anyOf.forEach(function(sch, i) {
@@ -647,7 +643,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     if (node.oneOf && node.oneOf.length) {
-      if (!Array.isArray(node.oneOf)) throw new Error('Invalid oneOf')
+      enforce(Array.isArray(node.oneOf), 'Invalid oneOf')
       const prev = gensym('prev')
       const passes = gensym('passes')
 
@@ -671,7 +667,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
 
     const multipleOf = node.multipleOf === undefined ? 'divisibleBy' : 'multipleOf' // draft3 support
     if (node[multipleOf] !== undefined) {
-      if (!Number.isFinite(node[multipleOf])) throw new Error(`Invalid ${multipleOf}`)
+      enforce(Number.isFinite(node[multipleOf]), `Invalid ${multipleOf}:`, node[multipleOf])
       validateTypeApplicable('number', 'integer')
       if (type !== 'number' && type !== 'integer') fun.write('if (%s) {', types.number(name))
 
@@ -686,7 +682,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     if (node.maxProperties !== undefined) {
-      if (!Number.isFinite(node.maxProperties)) throw new Error('Invalid maxProperties')
+      enforce(Number.isFinite(node.maxProperties), 'Invalid maxProperties:', node.maxProperties)
       validateTypeApplicable('object')
       if (type !== 'object') fun.write('if (%s) {', types.object(name))
 
@@ -699,7 +695,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     if (node.minProperties !== undefined) {
-      if (!Number.isFinite(node.minProperties)) throw new Error('Invalid minProperties')
+      enforce(Number.isFinite(node.minProperties), 'Invalid minProperties:', node.minProperties)
       validateTypeApplicable('object')
       if (type !== 'object') fun.write('if (%s) {', types.object(name))
 
@@ -712,9 +708,9 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     if (node.maxItems !== undefined) {
-      if (!Number.isFinite(node.maxItems)) throw new Error('Invalid maxItems')
+      enforce(Number.isFinite(node.maxItems), 'Invalid maxItems:', node.maxItems)
       if (Array.isArray(node.items) && node.items.length > node.maxItems)
-        throw new Error('Invalid maxItems: mismatch with items array length')
+        fail(`Invalid maxItems: ${node.maxItems} is less than items array length`)
       validateTypeApplicable('array')
       if (type !== 'array') fun.write('if (%s) {', types.array(name))
 
@@ -727,7 +723,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     if (node.minItems !== undefined) {
-      if (!Number.isFinite(node.minItems)) throw new Error('Invalid maxItems')
+      enforce(Number.isFinite(node.minItems), 'Invalid minItems:', node.minItems)
       // can be higher that .items length with additionalItems
       validateTypeApplicable('array')
       if (type !== 'array') fun.write('if (%s) {', types.array(name))
@@ -741,7 +737,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     if (node.maxLength !== undefined) {
-      if (!Number.isFinite(node.maxLength)) throw new Error('Invalid maxItems')
+      enforce(Number.isFinite(node.maxLength), 'Invalid maxLength:', node.maxLength)
       validateTypeApplicable('string')
       if (type !== 'string') fun.write('if (%s) {', types.string(name))
 
@@ -755,7 +751,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     if (node.minLength !== undefined) {
-      if (!Number.isFinite(node.minLength)) throw new Error('Invalid maxItems')
+      enforce(Number.isFinite(node.minLength), 'Invalid minLength:', node.minLength)
       validateTypeApplicable('string')
       if (type !== 'string') fun.write('if (%s) {', types.string(name))
 
@@ -769,7 +765,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
     }
 
     const applyMinMax = (value, operator, message) => {
-      if (!Number.isFinite(value)) throw new Error('Invalid minimum or maximum')
+      enforce(Number.isFinite(value), 'Invalid minimum or maximum:', value)
       validateTypeApplicable('number', 'integer')
       if (type !== 'number' && type !== 'integer') fun.write('if (%s) {', types.number(name))
 
@@ -819,7 +815,7 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       if (type !== 'array') fun.write('}')
       consume('items')
     } else if (typeApplicable('array')) {
-      if (requireValidation) throw new Error('[requireValidation] items rule must be specified')
+      validationRequired('items rule must be specified')
     }
 
     if (node.contains || node.contains === false) {

--- a/index.js
+++ b/index.js
@@ -173,8 +173,8 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       if (!allErrors) fun.write('return false')
     }
 
-    const fail = (msg, value) => {
-      const comment = value !== undefined ? ` ${JSON.stringify(value)}` : ''
+    const fail = (msg, value = '') => {
+      const comment = value && ` ${JSON.stringify(value)}`
       throw new Error(`${msg}${comment} at #${toPointer(schemaPath)}`)
     }
     const enforce = (ok, ...args) => ok || fail(...args)

--- a/pointer.js
+++ b/pointer.js
@@ -1,5 +1,10 @@
 'use strict'
 
+function toPointer(path) {
+  if (path.length === 0) return ''
+  return `/${path.map((part) => `${part}`.replace(/~/g, '~0').replace(/\//g, '~1')).join('/')}`
+}
+
 function untilde(string) {
   if (!string.includes('~')) return string
   return string.replace(/~[01]/g, (match) => {
@@ -92,4 +97,4 @@ function resolveReference(root, additionalSchemas, ptr) {
   return results
 }
 
-module.exports = { get, joinPath, resolveReference }
+module.exports = { toPointer, get, joinPath, resolveReference }

--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -2,17 +2,6 @@ const tape = require('tape')
 const validator = require('../')
 const { get } = require('../pointer')
 
-function toPointer(path) {
-  if (!(path && path.length && path.join)) {
-    return ''
-  }
-  return `/${path.join('/')}`
-}
-
-function lookup(schema, err) {
-  return get(schema, toPointer(err.schemaPath))
-}
-
 const target = Symbol('target')
 
 tape('schemaPath', function(t) {
@@ -101,12 +90,12 @@ tape('schemaPath', function(t) {
     if (validate(data)) {
       return t.fail(`should have failed: ${message}`)
     }
-    t.deepEqual(lookup(schema, validate.errors[0])[target], targetValue, message)
+    t.deepEqual(get(schema, validate.errors[0].schemaPath)[target], targetValue, message)
   }
 
   // Top level errors
-  notOkAt(null, [], 'should target parent of failed type error')
-  notOkAt(undefined, [], 'should target parent of failed type error')
+  notOkAt(null, '', 'should target parent of failed type error')
+  notOkAt(undefined, '', 'should target parent of failed type error')
   notOkWithTarget(
     { invalidAdditionalProp: '*whistles innocently*' },
     'top level',
@@ -114,20 +103,20 @@ tape('schemaPath', function(t) {
   )
 
   // Errors in properties
-  notOkAt({ hello: 42 }, ['properties', 'hello'], 'should target property with type error')
+  notOkAt({ hello: 42 }, '/properties/hello', 'should target property with type error')
   notOkAt(
     { someItems: [42] },
-    ['properties', 'someItems', '0'],
+    '/properties/someItems/0',
     'should target specific someItems rule(0)'
   )
   notOkAt(
     { someItems: ['astring', 42] },
-    ['properties', 'someItems', '1'],
+    '/properties/someItems/1',
     'should target specific someItems rule(1)'
   )
   notOkAt(
     { someItems: ['astring', 42, 'not a boolean'] },
-    ['properties', 'someItems', 'additionalItems'],
+    '/properties/someItems/additionalItems',
     'should target additionalItems'
   )
   notOkWithTarget(
@@ -154,28 +143,28 @@ tape('schemaPath', function(t) {
 
   notOkAt(
     { aggregate: 'a-a' },
-    ['properties', 'aggregate', 'allOf', 0],
+    '/properties/aggregate/allOf/0',
     'should target specific rule in allOf (0)'
   )
   notOkAt(
     { aggregate: 'z-z' },
-    ['properties', 'aggregate', 'allOf', 1],
+    '/properties/aggregate/allOf/1',
     'should target specific rule in allOf (1)'
   )
   notOkAt(
     { aggregate: 'a:z' },
-    ['properties', 'aggregate', 'allOf', 2],
+    '/properties/aggregate/allOf/2',
     'should target specific rule in allOf (2)'
   )
   notOkAt(
     { aggregate: 'a--z' },
-    ['properties', 'aggregate', 'allOf', 3],
+    '/properties/aggregate/allOf/3',
     'should target specific rule in allOf (3)'
   )
 
   notOkAt(
     { notAString: 42 },
-    ['patternProperties', '.*String'],
+    '/patternProperties/.*String',
     'should target the specific pattern in patternProperties (wildcards)'
   )
   notOkAt(
@@ -183,7 +172,7 @@ tape('schemaPath', function(t) {
       'I am a String': 'I really am',
       '001100111011000111100': "Don't stand around jabbering when you're in mortal danger",
     },
-    ['patternProperties', '^[01]+$'],
+    '/patternProperties/^[01]+$',
     'should target the specific pattern in patternProperties ("binary" keys)'
   )
 


### PR DESCRIPTION
Static errors are now more verbose and include paths pointing to where the error occured in the schema.

Dynamic errors now use json pointer (string) to encode `schemaPath`.

Minor cleanup.