### PR TITLE
Drop "greedy" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,29 +132,6 @@ console.log( 'All evaluate to the same thing: ', R.equals(
 // All evaluate to the same thing: true
 ```
 
-## Greedy mode tries to validate as much as possible
-
-By default is-my-json-valid bails on first validation error but when greedy is
-set to true it tries to validate as much as possible:
-
-```js
-var validate = validator({
-  type: 'object',
-  properties: {
-    x: {
-      type: 'number'
-    }
-  },
-  required: ['x', 'y']
-}, {
-  greedy: true
-});
-
-validate({x: 'string'});
-console.log(validate.errors) // [{field: 'data.y', message: 'is required'},
-                             //  {field: 'data.x', message: 'is the wrong type'}]
-```
-
 ## Generate Modules
 
 To compile a validator function to an IIFE, call `validate.toModule()`:

--- a/index.js
+++ b/index.js
@@ -106,7 +106,6 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
   const {
     mode = 'default',
     verbose = false,
-    greedy = false,
     applyDefault = false,
     allErrors: optAllErrors = false,
     dryRun = false,
@@ -413,10 +412,6 @@ const compile = function(schema, root, reporter, opts, scope, basePathRoot) {
       fun.write('var %s = 0', missing)
       node.required.map(checkRequired)
       if (type !== 'object') fun.write('}')
-      if (!greedy) {
-        fun.write('if (%s === 0) {', missing)
-        indent++
-      }
       consume('required')
     }
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "format": "prettier --write '**/*.js'",
     "test": "npm run test:normal | tap-spec && npm run test:module | tap-spec",
     "test:raw": "npm run test:normal && npm run test:module",
-    "test:module": "tape -r ./test-module.js test/*.js",
-    "test:normal": "tape test/*.js"
+    "test:module": "tape -r ./test-module.js test/*.js test/regressions/*.js",
+    "test:normal": "tape test/*.js test/regressions/*.js"
   },
   "dependencies": {
   },

--- a/test/misc.js
+++ b/test/misc.js
@@ -35,7 +35,7 @@ tape('advanced', function(t) {
   t.end()
 })
 
-tape('greedy/false', function(t) {
+tape('allErrors/false', function(t) {
   const validate = validator(
     {
       type: 'object',
@@ -46,14 +46,12 @@ tape('greedy/false', function(t) {
       },
       required: ['x', 'y'],
     },
-    { allErrors: true }
+    { allErrors: false }
   )
   t.notOk(validate({}), 'should be invalid')
-  t.strictEqual(validate.errors.length, 2)
+  t.strictEqual(validate.errors.length, 1)
   t.strictEqual(validate.errors[0].field, 'data["x"]')
   t.strictEqual(validate.errors[0].message, 'is required')
-  t.strictEqual(validate.errors[1].field, 'data["y"]')
-  t.strictEqual(validate.errors[1].message, 'is required')
   t.notOk(validate({ x: 'string' }), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
   t.strictEqual(validate.errors[0].field, 'data["y"]')
@@ -65,7 +63,7 @@ tape('greedy/false', function(t) {
   t.end()
 })
 
-tape('greedy/true', function(t) {
+tape('allErrors/true', function(t) {
   const validate = validator(
     {
       type: 'object',
@@ -76,10 +74,7 @@ tape('greedy/true', function(t) {
       },
       required: ['x', 'y'],
     },
-    {
-      greedy: true,
-      allErrors: true,
-    }
+    { allErrors: true }
   )
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 2)

--- a/test/regressions/broken-required.js
+++ b/test/regressions/broken-required.js
@@ -1,0 +1,10 @@
+const tape = require('tape')
+const validator = require('../../')
+
+const runWithOptions = (t, opts) => {
+  t.notOk(validator({ required: [], uniqueItems: true }, opts)([1, 1]), 'required + uniqueItems')
+  t.end()
+}
+
+tape('default', (t) => runWithOptions(t, {}))
+tape('allErrors', (t) => runWithOptions(t, { allErrors: true }))

--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -88,7 +88,7 @@ tape('schemaPath', function(t) {
     },
     additionalProperties: false,
   }
-  const validate = validator(schema, { verbose: true, greedy: true })
+  const validate = validator(schema, { verbose: true })
 
   function notOkAt(data, path, message) {
     if (validate(data)) {
@@ -226,7 +226,7 @@ tape('schemaPath - nested selectors', function(t) {
       },
     ],
   }
-  const validate = validator(schema, { verbose: true, greedy: true })
+  const validate = validator(schema, { verbose: true })
   t.notOk(validate({ nestedSelectors: 'nope' }), 'should not crash on visit inside *Of')
 
   t.end()


### PR DESCRIPTION
1) allErrors superseeds it
2) it was significantly broken out of the box (see regression test)