### PR TITLE
format is effective only on strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -419,7 +419,7 @@ const compile = (schema, root, reporter, opts, scope, basePathRoot) => {
 
     if (node.format && fmts.hasOwnProperty(node.format)) {
       validateTypeApplicable('string')
-      if (type !== 'string' && formats[node.format]) fun.write('if (%s) {', types.string(name))
+      if (type !== 'string') fun.write('if (%s) {', types.string(name))
       const format = fmts[node.format]
       if (format instanceof RegExp || typeof format === 'function') {
         let n = formatCache.get(format)
@@ -432,11 +432,10 @@ const compile = (schema, root, reporter, opts, scope, basePathRoot) => {
         fun.write(`if (${condition}) {`, n, name)
         error(`must be ${node.format} format`)
         fun.write('}')
-      } else if (typeof format === 'object') {
-        rule(name, format, subPath('format'))
+      } else {
+        fail('Unrecognized format used:', node.format)
       }
-
-      if (type !== 'string' && formats[node.format]) fun.write('}')
+      if (type !== 'string') fun.write('}')
       consume('format')
     } else {
       enforce(!node.format, 'Unrecognized format used:', node.format)

--- a/test/misc.js
+++ b/test/misc.js
@@ -275,40 +275,6 @@ tape('custom format function', function(t) {
   t.end()
 })
 
-tape('custom format schema object', function(t) {
-  const tests = [
-    {
-      schema: { format: 'vegetable' },
-      description: 'an egglplant is a vegetable',
-      data: { oblong: true, sweet: false },
-      valid: true,
-    },
-    {
-      schema: { format: 'vegetable' },
-      description: 'a strawberry is not a vegetable',
-      data: { oblong: false, sweet: true },
-      valid: false,
-    },
-  ]
-
-  const formats = {
-    vegetable: {
-      type: 'object',
-      properties: {
-        oblong: { enum: [true] },
-        sweet: { enum: [false] },
-      },
-    },
-  }
-
-  tests.forEach(function(f) {
-    const validate = validator(f.schema, { formats: formats })
-    t.is(validate(f.data), f.valid, f.description)
-  })
-
-  t.end()
-})
-
 tape('unknown format throws errors', function(t) {
   t.throws(function() {
     validator({ type: 'string', format: 'foobar' })


### PR DESCRIPTION
Drop non-standard object format support.
References should be used instead.

Refs: https://json-schema.org/understanding-json-schema/reference/string.html#format