### PR TITLE
Opt in to includeErrors, error generation options cleanup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -163,7 +163,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
   const visit = (allErrors, includeErrors, name, node, schemaPath) => {
     const rule = (...args) => visit(allErrors, includeErrors, ...args)
     const subrule = (...args) => visit(true, false, ...args)
-    const writeError = (format, ...params) => {
+    const writeErrorObject = (format, ...params) => {
       if (allErrors) {
         fun.write('if (validate.errors === null) validate.errors = []')
         fun.write(`validate.errors.push(${format})`, ...params)
@@ -179,9 +179,9 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
         if (verboseErrors) {
           const type = node.type || 'any'
           Object.assign(errorObject, { type, schemaPath: toPointer(schemaPath) })
-          writeError('{ ...%s, value: %s }', JSON.stringify(errorObject), value || name)
+          writeErrorObject('{ ...%s, value: %s }', JSON.stringify(errorObject), value || name)
         } else {
-          writeError('%s', JSON.stringify(errorObject))
+          writeErrorObject('%s', JSON.stringify(errorObject))
         }
       }
       if (!allErrors) fun.write('return false')

--- a/src/index.js
+++ b/src/index.js
@@ -102,10 +102,10 @@ const rootMeta = new WeakMap()
 const compile = (schema, root, opts, scope, basePathRoot) => {
   const {
     mode = 'default',
-    verbose = false,
     applyDefault = false,
     includeErrors: optIncludeErrors = false,
     allErrors: optAllErrors = false,
+    verboseErrors = false,
     dryRun = false,
     allowUnusedKeywords = opts.mode === 'lax',
     requireValidation = opts.mode === 'strong',
@@ -176,7 +176,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       fun.write('errors++')
       if (includeErrors === true) {
         const errorObject = { field: prop || name, message: msg }
-        if (verbose) {
+        if (verboseErrors) {
           const type = node.type || 'any'
           Object.assign(errorObject, { type, schemaPath: toPointer(schemaPath) })
           writeError('{ ...%s, value: %s }', JSON.stringify(errorObject), value || name)

--- a/src/index.js
+++ b/src/index.js
@@ -99,11 +99,12 @@ const schemaVersions = [
 ]
 
 const rootMeta = new WeakMap()
-const compile = (schema, root, reporter, opts, scope, basePathRoot) => {
+const compile = (schema, root, opts, scope, basePathRoot) => {
   const {
     mode = 'default',
     verbose = false,
     applyDefault = false,
+    includeErrors: optIncludeErrors = true,
     allErrors: optAllErrors = false,
     dryRun = false,
     allowUnusedKeywords = opts.mode === 'lax',
@@ -155,28 +156,32 @@ const compile = (schema, root, reporter, opts, scope, basePathRoot) => {
   fun.write('function validate(data) {')
   // Since undefined is not a valid JSON value, we coerce to null and other checks will catch this
   fun.write('if (data === undefined) data = null')
-  if (reporter === true) fun.write('validate.errors = null')
+  if (optIncludeErrors) fun.write('validate.errors = null')
   fun.write('let errors = 0')
 
   const basePathStack = basePathRoot ? [basePathRoot] : []
-  const visit = (allErrors, reporter, name, node, schemaPath) => {
-    const rule = (...args) => visit(allErrors, reporter, ...args)
+  const visit = (allErrors, includeErrors, name, node, schemaPath) => {
+    const rule = (...args) => visit(allErrors, includeErrors, ...args)
     const subrule = (...args) => visit(true, false, ...args)
+    const writeError = (format, ...params) => {
+      if (allErrors) {
+        fun.write('if (validate.errors === null) validate.errors = []')
+        fun.write(`validate.errors.push(${format})`, ...params)
+      } else {
+        fun.write(`validate.errors = [${format}]`, ...params)
+        fun.write('return false')
+      }
+    }
     const error = (msg, prop, value) => {
       fun.write('errors++')
-      if (reporter === true) {
-        fun.write('if (validate.errors === null) validate.errors = []')
+      if (includeErrors === true) {
         const errorObject = { field: prop || name, message: msg }
         if (verbose) {
           const type = node.type || 'any'
           Object.assign(errorObject, { type, schemaPath: toPointer(schemaPath) })
-          fun.write(
-            'validate.errors.push({ ...%s, value: %s })',
-            JSON.stringify(errorObject),
-            value || name
-          )
+          writeError('{ ...%s, value: %s }', JSON.stringify(errorObject), value || name)
         } else {
-          fun.write('validate.errors.push(%s)', JSON.stringify(errorObject))
+          writeError('%s', JSON.stringify(errorObject))
         }
       }
       if (!allErrors) fun.write('return false')
@@ -284,7 +289,7 @@ const compile = (schema, root, reporter, opts, scope, basePathRoot) => {
           refCache.set(sub, n)
           let fn = null // resolve cyclic dependencies
           scope[n] = (...args) => fn(...args)
-          fn = compile(sub, subRoot, false, opts, scope, path)
+          fn = compile(sub, subRoot, { ...opts, includeErrors: false }, scope, path)
           scope[n] = fn
         }
         fun.write('if (!(%s(%s))) {', n, name)
@@ -849,7 +854,7 @@ const compile = (schema, root, reporter, opts, scope, basePathRoot) => {
     finish()
   }
 
-  visit(optAllErrors, reporter, 'data', schema, [])
+  visit(optAllErrors, optIncludeErrors, 'data', schema, [])
 
   fun.write('return errors === 0')
   fun.write('}')
@@ -864,7 +869,7 @@ const compile = (schema, root, reporter, opts, scope, basePathRoot) => {
 
 const validator = function(schema, opts = {}) {
   if (typeof schema === 'string') schema = JSON.parse(schema)
-  return compile(schema, schema, true, opts)
+  return compile(schema, schema, opts)
 }
 
 const parser = function(schema, opts = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
         fun.write('if (validate.errors === null) validate.errors = []')
         fun.write(`validate.errors.push(${format})`, ...params)
       } else {
+        // Array assignment is significantly faster, do not refactor the two branches
         fun.write(`validate.errors = [${format}]`, ...params)
         fun.write('return false')
       }

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     mode = 'default',
     verbose = false,
     applyDefault = false,
-    includeErrors: optIncludeErrors = true,
+    includeErrors: optIncludeErrors = false,
     allErrors: optAllErrors = false,
     dryRun = false,
     allowUnusedKeywords = opts.mode === 'lax',

--- a/test/misc.js
+++ b/test/misc.js
@@ -46,7 +46,7 @@ tape('allErrors/false', function(t) {
       },
       required: ['x', 'y'],
     },
-    { allErrors: false }
+    { includeErrors: true, allErrors: false }
   )
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
@@ -74,7 +74,7 @@ tape('allErrors/true', function(t) {
       },
       required: ['x', 'y'],
     },
-    { allErrors: true }
+    { includeErrors: true, allErrors: true }
   )
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 2)
@@ -103,6 +103,7 @@ tape('additional props', function(t) {
       additionalProperties: false,
     },
     {
+      includeErrors: true,
       verbose: true,
     }
   )
@@ -395,7 +396,7 @@ tape('nested required array decl', function(t) {
     required: ['x'],
   }
 
-  const validate = validator(schema)
+  const validate = validator(schema, { includeErrors: true })
 
   t.ok(validate({ x: {} }), 'should be valid')
   t.notOk(validate({}), 'should not be valid')
@@ -415,7 +416,7 @@ tape('verbose mode', function(t) {
     },
   }
 
-  const validate = validator(schema, { verbose: true })
+  const validate = validator(schema, { includeErrors: true, verbose: true })
 
   t.ok(validate({ hello: 'string' }), 'should be valid')
   t.notOk(validate({ hello: 100 }), 'should not be valid')
@@ -446,7 +447,7 @@ tape('additional props in verbose mode', function(t) {
     },
   }
 
-  const validate = validator(schema, { verbose: true })
+  const validate = validator(schema, { includeErrors: true, verbose: true })
 
   validate({ 'hello world': { bar: 'string' } })
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -104,7 +104,7 @@ tape('additional props', function(t) {
     },
     {
       includeErrors: true,
-      verbose: true,
+      verboseErrors: true,
     }
   )
 
@@ -416,7 +416,7 @@ tape('verbose mode', function(t) {
     },
   }
 
-  const validate = validator(schema, { includeErrors: true, verbose: true })
+  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
 
   t.ok(validate({ hello: 'string' }), 'should be valid')
   t.notOk(validate({ hello: 100 }), 'should not be valid')
@@ -447,7 +447,7 @@ tape('additional props in verbose mode', function(t) {
     },
   }
 
-  const validate = validator(schema, { includeErrors: true, verbose: true })
+  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
 
   validate({ 'hello world': { bar: 'string' } })
 

--- a/test/regressions/contains-errors.js
+++ b/test/regressions/contains-errors.js
@@ -2,7 +2,7 @@ const tape = require('tape')
 const validator = require('../../')
 
 tape('contains does not pollute errors', (t) => {
-  const validate = validator({ type: 'array', contains: { const: 2 } })
+  const validate = validator({ type: 'array', contains: { const: 2 } }, { includeErrors: true })
 
   t.ok(validate([1, 2]), 'valid contains')
   t.strictEqual(validate.errors, null, 'errors object is empty')

--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -77,7 +77,7 @@ tape('schemaPath', function(t) {
     },
     additionalProperties: false,
   }
-  const validate = validator(schema, { includeErrors: true, verbose: true })
+  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
 
   function notOkAt(data, path, message) {
     if (validate(data)) {
@@ -215,7 +215,7 @@ tape('schemaPath - nested selectors', function(t) {
       },
     ],
   }
-  const validate = validator(schema, { includeErrors: true, verbose: true })
+  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
   t.notOk(validate({ nestedSelectors: 'nope' }), 'should not crash on visit inside *Of')
 
   t.end()

--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -77,7 +77,7 @@ tape('schemaPath', function(t) {
     },
     additionalProperties: false,
   }
-  const validate = validator(schema, { verbose: true })
+  const validate = validator(schema, { includeErrors: true, verbose: true })
 
   function notOkAt(data, path, message) {
     if (validate(data)) {
@@ -215,7 +215,7 @@ tape('schemaPath - nested selectors', function(t) {
       },
     ],
   }
-  const validate = validator(schema, { verbose: true })
+  const validate = validator(schema, { includeErrors: true, verbose: true })
   t.notOk(validate({ nestedSelectors: 'nope' }), 'should not crash on visit inside *Of')
 
   t.end()


### PR DESCRIPTION
No reason to enable error generation unless they are needed.
Without them, the code is cleaner and faster.

Also cleanup error-related options.