### PR TITLE
Fix numeric types and comparisons

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,8 @@ types.null = (name) => `${name} === null`
 types.boolean = (name) => `typeof ${name} === "boolean"`
 types.array = (name) => `Array.isArray(${name})`
 types.object = (name) => `typeof ${name} === "object" && ${name} && !Array.isArray(${name})`
-types.number = (name) => `typeof ${name} === "number" && isFinite(${name})`
-types.integer = (name) =>
-  `typeof ${name} === "number" && (Math.floor(${name}) === ${name} || ${name} > 9007199254740992 || ${name} < -9007199254740992)`
+types.number = (name) => `typeof ${name} === "number"`
+types.integer = (name) => `Number.isInteger(${name})`
 types.string = (name) => `typeof ${name} === "string"`
 
 const unique = (array) => {
@@ -350,7 +349,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       validateTypeApplicable('number', 'integer')
       if (type !== 'number' && type !== 'integer') fun.write('if (%s) {', types.number(name))
 
-      fun.write('if (%s %s %d) {', name, operator, value)
+      fun.write('if (!(%d %s %s)) {', value, operator, name)
       error(message)
       fun.write('}')
 
@@ -358,19 +357,19 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     }
 
     if (Number.isFinite(node.exclusiveMinimum)) {
-      applyMinMax(node.exclusiveMinimum, '<=', 'is less than exclusiveMinimum')
+      applyMinMax(node.exclusiveMinimum, '<', 'is less than exclusiveMinimum')
       consume('exclusiveMinimum')
     } else if (node.minimum !== undefined) {
-      applyMinMax(node.minimum, node.exclusiveMinimum ? '<=' : '<', 'is less than minimum')
+      applyMinMax(node.minimum, node.exclusiveMinimum ? '<' : '<=', 'is less than minimum')
       consume('minimum')
       if (typeof node.exclusiveMinimum === 'boolean') consume('exclusiveMinimum')
     }
 
     if (Number.isFinite(node.exclusiveMaximum)) {
-      applyMinMax(node.exclusiveMaximum, '>=', 'is more than exclusiveMaximum')
+      applyMinMax(node.exclusiveMaximum, '>', 'is more than exclusiveMaximum')
       consume('exclusiveMaximum')
     } else if (node.maximum !== undefined) {
-      applyMinMax(node.maximum, node.exclusiveMaximum ? '>=' : '>', 'is more than maximum')
+      applyMinMax(node.maximum, node.exclusiveMaximum ? '>' : '>=', 'is more than maximum')
       consume('maximum')
       if (typeof node.exclusiveMaximum === 'boolean') consume('exclusiveMaximum')
     }

--- a/test/regressions/numbers.js
+++ b/test/regressions/numbers.js
@@ -1,0 +1,62 @@
+const tape = require('tape')
+const validator = require('../../')
+
+tape('number', (t) => {
+  const validate = validator({ type: 'number' })
+
+  t.ok(validate(0), '0 is a number')
+  t.ok(validate(Infinity), 'Infinity is a number')
+  t.ok(validate(NaN), 'NaN is a number')
+  t.notOk(validate('1'), 'string is not a number')
+  t.ok(validate(1), '1 is a number')
+  t.ok(validate(1.5), '1.5 is a number')
+  t.ok(validate(Number.MAX_SAFE_INTEGER), 'MAX_SAFE_INTEGER is a number')
+  t.ok(validate(2 * Number.MAX_SAFE_INTEGER), '2 * MAX_SAFE_INTEGER is a number')
+
+  t.end()
+})
+
+tape('integer', (t) => {
+  const validate = validator({ type: 'integer' })
+
+  t.ok(validate(0), '0 is an integer')
+  t.notOk(validate(Infinity), 'Infinity is not an integer')
+  t.notOk(validate(NaN), 'NaN is not an integer')
+  t.notOk(validate('1'), 'string is not an integer')
+  t.ok(validate(1), '1 is an integer')
+  t.notOk(validate(1.5), '1.5 is not an integer')
+  t.ok(validate(Number.MAX_SAFE_INTEGER), 'MAX_SAFE_INTEGER is an integer')
+  t.ok(validate(2 * Number.MAX_SAFE_INTEGER), '2 * MAX_SAFE_INTEGER is an integer')
+
+  t.end()
+})
+
+tape('maximum', (t) => {
+  const validate = validator({ maximum: 1 })
+
+  t.ok(validate(0), '0 <= 1')
+  t.notOk(validate(Infinity), '!(Infinity <= 1)')
+  t.notOk(validate(NaN), '!(NaN <= 1)')
+  t.ok(validate('1'), 'string is not a number so is allowed unless type is checked')
+  t.ok(validate(1), '1 <= 1')
+  t.notOk(validate(1.5), '!(1.5 <= 1)')
+  t.notOk(validate(Number.MAX_SAFE_INTEGER), '!(MAX_SAFE_INTEGER <= 1)')
+  t.notOk(validate(2 * Number.MAX_SAFE_INTEGER), '!(2 * MAX_SAFE_INTEGER <= 1)')
+
+  t.end()
+})
+
+tape('minimum', (t) => {
+  const validate = validator({ minimum: 1 })
+
+  t.notOk(validate(0), '!(0 >= 1)')
+  t.ok(validate(Infinity), 'Infinity >= 1')
+  t.notOk(validate(NaN), '!(NaN >= 1)')
+  t.ok(validate('1'), 'string is not a number so is allowed unless type is checked')
+  t.ok(validate(1), '1 >= 1')
+  t.ok(validate(1.5), '1.5 >= 1')
+  t.ok(validate(Number.MAX_SAFE_INTEGER), 'MAX_SAFE_INTEGER >= 1')
+  t.ok(validate(2 * Number.MAX_SAFE_INTEGER), '2 * MAX_SAFE_INTEGER >= 1')
+
+  t.end()
+})


### PR DESCRIPTION
Regression tests included.

* `NaN`, `Infinity`, `-Infinity` are now correct `number` types (`NaN` is not possible in JSON)
* `Infinity`, `-Infinity` are now not `integer` (yes, they were integers but not numbers previously!)
* `Infinity` now fails `maximum` checks even if no type is enfoced (because it's a number and subject to those checks)
* `NaN` now fails all numeric comparison checks (because it's a number), because of this checks were inverted

`ajv` consideres `Infinity` to be an integer (unlike this impl), but that seems very strange.