### PR TITLE
Don't run useless undefined check at root

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,6 +159,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
   if (optIncludeErrors) fun.write('validate.errors = null')
   fun.write('let errors = 0')
 
+  const getMeta = (flag) => rootMeta.get(root) || {}
   const basePathStack = basePathRoot ? [basePathRoot] : []
   const visit = (allErrors, includeErrors, name, node, schemaPath) => {
     const rule = (...args) => visit(allErrors, includeErrors, ...args)
@@ -219,8 +220,9 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       unused.delete(property)
     }
 
+    const isTopLevel = name === 'data'
     const finish = () => {
-      fun.write('}') // undefined check
+      if (!isTopLevel) fun.write('}') // undefined check
       enforce(unused.size === 0 || allowUnusedKeywords, 'Unprocessed keywords:', [...unused])
     }
 
@@ -233,11 +235,12 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       if ($schema) {
         const version = $schema.replace(/^http:\/\//, 'https://').replace(/#$/, '')
         enforce(schemaVersions.includes(version), 'Unexpected schema version:', version)
+        const schemaIsOlderThan = (ver) =>
+          schemaVersions.indexOf(version) >
+          schemaVersions.indexOf(`https://json-schema.org/${ver}/schema`)
         rootMeta.set(root, {
-          exclusiveRefs:
-            // older than draft/2019-09
-            schemaVersions.indexOf(version) >
-            schemaVersions.indexOf('https://json-schema.org/draft/2019-09/schema'),
+          exclusiveRefs: schemaIsOlderThan('draft/2019-09'),
+          booleanRequired: schemaIsOlderThan('draft-04'),
         })
       }
     }
@@ -263,23 +266,37 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       consume('id')
     }
 
-    fun.write('if (%s === undefined) {', name)
-    let defaultApplied = false
-    if (node.default !== undefined) {
-      if (applyDefault) {
-        if (node === root || name === 'data') fail('Can not apply default value at root')
-        fun.write('%s = %s', name, jaystring(node.default))
-        defaultApplied = true
+    const booleanRequired = getMeta().booleanRequired && typeof node.required === 'boolean'
+    if (isTopLevel) {
+      // top-level data is coerced to null above, it can't be undefined
+      if (node.default !== undefined) {
+        enforce(!applyDefault, 'Can not apply default value at root')
+        consume('default')
       }
-      consume('default')
+      if (node.required === true || node.required === false)
+        fail('Can not apply boolean required at root')
+    } else if (node.default !== undefined || booleanRequired) {
+      fun.write('if (%s === undefined) {', name)
+      let defaultApplied = false
+      if (node.default !== undefined) {
+        if (applyDefault) {
+          fun.write('%s = %s', name, jaystring(node.default))
+          defaultApplied = true
+        }
+        consume('default')
+      }
+      if (booleanRequired) {
+        if (node.required === true) {
+          if (!defaultApplied) error('is required')
+          consume('required')
+        } else if (node.required === false) {
+          consume('required')
+        }
+      }
+      fun.write('} else {')
+    } else {
+      fun.write('if (%s !== undefined) {', name)
     }
-    if (node.required === true) {
-      if (!defaultApplied) error('is required')
-      consume('required')
-    } else if (node.required === false) {
-      consume('required')
-    }
-    fun.write('} else {')
 
     if (node.$ref) {
       const resolved = resolveReference(root, schemas || {}, joinPath(basePath(), node.$ref))
@@ -302,7 +319,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       }
       consume('$ref')
 
-      if (rootMeta.has(root) && rootMeta.get(root).exclusiveRefs) {
+      if (getMeta().exclusiveRefs) {
         // ref overrides any sibling keywords for older schemas
         finish()
         return

--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
   if (optIncludeErrors) fun.write('validate.errors = null')
   fun.write('let errors = 0')
 
-  const getMeta = (flag) => rootMeta.get(root) || {}
+  const getMeta = () => rootMeta.get(root) || {}
   const basePathStack = basePathRoot ? [basePathRoot] : []
   const visit = (allErrors, includeErrors, name, node, schemaPath) => {
     const rule = (...args) => visit(allErrors, includeErrors, ...args)

--- a/test/misc.js
+++ b/test/misc.js
@@ -4,10 +4,10 @@ const validator = require('../')
 
 tape('simple', function(t) {
   const schema = {
-    required: true,
     type: 'object',
+    required: ['hello'],
     properties: {
-      hello: { type: 'string', required: true },
+      hello: { type: 'string' },
     },
   }
 
@@ -121,14 +121,12 @@ tape('additional props', function(t) {
 tape('array', function(t) {
   const validate = validator({
     type: 'array',
-    required: true,
     items: {
       type: 'string',
     },
   })
 
   t.notOk(validate({}), 'wrong type')
-  t.notOk(validate(), 'is required')
   t.ok(validate(['test']))
   t.end()
 })
@@ -136,10 +134,10 @@ tape('array', function(t) {
 tape('nested array', function(t) {
   const validate = validator({
     type: 'object',
+    required: ['list'],
     properties: {
       list: {
         type: 'array',
-        required: true,
         items: {
           type: 'string',
         },
@@ -156,10 +154,10 @@ tape('nested array', function(t) {
 tape('enum', function(t) {
   const validate = validator({
     type: 'object',
+    required: ['foo'],
     properties: {
       foo: {
         type: 'number',
-        required: true,
         enum: [42],
       },
     },
@@ -302,10 +300,10 @@ tape('do not mutate schema', function(t) {
 
 tape('#toJSON()', function(t) {
   const schema = {
-    required: true,
     type: 'object',
+    required: ['hello'],
     properties: {
-      hello: { type: 'string', required: true },
+      hello: { type: 'string' },
     },
   }
 
@@ -318,7 +316,6 @@ tape('#toJSON()', function(t) {
 tape('external schemas', function(t) {
   const ext = { type: 'string' }
   const schema = {
-    required: true,
     $ref: '#ext',
   }
 
@@ -332,7 +329,6 @@ tape('external schemas', function(t) {
 tape('external schema URIs', function(t) {
   const ext = { type: 'string' }
   const schema = {
-    required: true,
     $ref: 'http://example.com/schemas/schemaURIs',
   }
 
@@ -406,11 +402,10 @@ tape('nested required array decl', function(t) {
 
 tape('verbose mode', function(t) {
   const schema = {
-    required: true,
     type: 'object',
+    required: ['hello'],
     properties: {
       hello: {
-        required: true,
         type: 'string',
       },
     },
@@ -428,15 +423,14 @@ tape('verbose mode', function(t) {
 tape('additional props in verbose mode', function(t) {
   const schema = {
     type: 'object',
-    required: true,
     additionalProperties: false,
+    required: ['hello world'],
     properties: {
       foo: {
         type: 'string',
       },
       'hello world': {
         type: 'object',
-        required: true,
         additionalProperties: false,
         properties: {
           foo: {
@@ -474,10 +468,10 @@ tape.skip('field shows item index in arrays', function(t) {
     items: {
       type: 'array',
       items: {
+        required: ['foo'],
         properties: {
           foo: {
             type: 'string',
-            required: true,
           },
         },
       },


### PR DESCRIPTION
* Don't run useless undefined check at root.
* Also guard boolean `required` to be supported only on draft-03 version.
* Make output more readable by preventing empty `if (%s === undefined)` block on top of every check.

 Before (without applying default or draft-03 only boolean require):
   ```js
   if (data[key0] === undefined) {
   } else {
   ```
  After:
   ```js
   if (data[key0] !== undefined) {
   ```