### PR TITLE
Simplify write(), support only single lines

### DIFF
--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -21,7 +21,7 @@ module.exports = () => {
   return {
     write(fmt, ...args) {
       if (typeof fmt !== 'string') throw new Error('Format must be a string!')
-      if (args.length === 1 && fmt.indexOf('\n') > -1) {
+      if (args.length === 0 && fmt.indexOf('\n') > -1) {
         // multiple lines with no parameters, push them separately for correct indent
         const lines = fmt.trim().split('\n')
         for (const line of lines) {

--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -21,16 +21,8 @@ module.exports = () => {
   return {
     write(fmt, ...args) {
       if (typeof fmt !== 'string') throw new Error('Format must be a string!')
-      if (args.length === 0 && fmt.indexOf('\n') > -1) {
-        // multiple lines with no parameters, push them separately for correct indent
-        const lines = fmt.trim().split('\n')
-        for (const line of lines) {
-          pushLine(line.trim())
-        }
-      } else {
-        // format + parameters case
-        pushLine(utilFormat(fmt, ...args))
-      }
+      if (fmt.includes('\n')) throw new Error('Only single lines are supported')
+      pushLine(args.length > 0 ? utilFormat(fmt, ...args) : fmt)
     },
 
     makeRawSource() {


### PR DESCRIPTION
There was a mistake in the multi-line write() method (see first commit)

Second commit just removes it as it was unused and added needless complexity.