### PR TITLE
Group equivalent type checks per-block

### DIFF
--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -25,6 +25,20 @@ module.exports = () => {
       pushLine(args.length > 0 ? utilFormat(fmt, ...args) : fmt)
     },
 
+    block(fmt, args, close, writeBody) {
+      const oldIndent = indent
+      this.write(fmt, ...args)
+      const length = lines.length
+      writeBody()
+      if (length === lines.length) {
+        // no lines inside block, unwind the block
+        lines.pop()
+        indent = oldIndent
+        return
+      }
+      this.write(close)
+    },
+
     makeRawSource() {
       return lines.join('\n')
     },

--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -25,6 +25,10 @@ module.exports = () => {
       pushLine(args.length > 0 ? utilFormat(fmt, ...args) : fmt)
     },
 
+    size() {
+      return lines.length
+    },
+
     block(fmt, args, close, writeBody) {
       const oldIndent = indent
       this.write(fmt, ...args)


### PR DESCRIPTION
This significantly simplifies generated code.

More common logic is introduced to enforce that non-applicable blocks do not have any related properties and do not generate any code.