### PR TITLE
Replace util.format with a clean impl

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "src/index.js",
   "files": [
     "src/generate-function.js",
+    "src/safe-format.js",
     "src/jaystring.js",
     "src/formats.js",
     "src/scope-functions.js",

--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -4,7 +4,7 @@ const INDENT_START = /[{[]/
 const INDENT_END = /[}\]]/
 
 const format = (fmt, ...args) => {
-  const res = fmt.replace(/%[%ds]/g, (match) => {
+  const res = fmt.replace(/%[%dsj]/g, (match) => {
     if (match === '%%') return '%'
     if (args.length === 0) throw new Error('Unexpected arguments count')
     const val = args.shift()
@@ -15,6 +15,8 @@ const format = (fmt, ...args) => {
       case '%s':
         if (typeof val === 'string') return val
         throw new Error('Expected a string')
+      case '%j':
+        return JSON.stringify(val)
       case '%%':
         return '%'
     }

--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -1,8 +1,28 @@
-const { format: utilFormat } = require('util')
 const jaystring = require('./jaystring')
 
 const INDENT_START = /[{[]/
 const INDENT_END = /[}\]]/
+
+const format = (fmt, ...args) => {
+  const res = fmt.replace(/%[%ds]/g, (match) => {
+    if (match === '%%') return '%'
+    if (args.length === 0) throw new Error('Unexpected arguments count')
+    const val = args.shift()
+    switch (match) {
+      case '%d':
+        if (typeof val === 'number') return val
+        throw new Error('Expected a number')
+      case '%s':
+        if (typeof val === 'string') return val
+        throw new Error('Expected a string')
+      case '%%':
+        return '%'
+    }
+    throw new Error(`Unreachable`)
+  })
+  if (args.length !== 0) throw new Error('Unexpected arguments count')
+  return res
+}
 
 module.exports = () => {
   const lines = []
@@ -22,7 +42,7 @@ module.exports = () => {
     write(fmt, ...args) {
       if (typeof fmt !== 'string') throw new Error('Format must be a string!')
       if (fmt.includes('\n')) throw new Error('Only single lines are supported')
-      pushLine(args.length > 0 ? utilFormat(fmt, ...args) : fmt)
+      pushLine(args.length > 0 ? format(fmt, ...args) : fmt)
     },
 
     size() {

--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -17,8 +17,6 @@ const format = (fmt, ...args) => {
         throw new Error('Expected a string')
       case '%j':
         return JSON.stringify(val)
-      case '%%':
-        return '%'
     }
     throw new Error(`Unreachable`)
   })

--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -4,7 +4,7 @@ const INDENT_START = /[{[]/
 const INDENT_END = /[}\]]/
 
 const format = (fmt, ...args) => {
-  const res = fmt.replace(/%[%dsj]/g, (match) => {
+  const res = fmt.replace(/%[%dscj]/g, (match) => {
     if (match === '%%') return '%'
     if (args.length === 0) throw new Error('Unexpected arguments count')
     const val = args.shift()
@@ -15,6 +15,9 @@ const format = (fmt, ...args) => {
       case '%s':
         if (typeof val === 'string') return val
         throw new Error('Expected a string')
+      case '%c':
+        if (['<', '>', '<=', '>='].includes(val)) return val
+        throw new Error('Expected a compare op')
       case '%j':
         return JSON.stringify(val)
     }

--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -19,6 +19,7 @@ const format = (fmt, ...args) => {
         if (['<', '>', '<=', '>='].includes(val)) return val
         throw new Error('Expected a compare op')
       case '%j':
+        if ([Infinity, -Infinity, NaN, undefined].includes(val)) return `${val}`
         return JSON.stringify(val)
     }
     throw new Error(`Unreachable`)

--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -1,32 +1,8 @@
+const { format } = require('./safe-format')
 const jaystring = require('./jaystring')
 
 const INDENT_START = /[{[]/
 const INDENT_END = /[}\]]/
-
-const format = (fmt, ...args) => {
-  const res = fmt.replace(/%[%dscj]/g, (match) => {
-    if (match === '%%') return '%'
-    if (args.length === 0) throw new Error('Unexpected arguments count')
-    const val = args.shift()
-    switch (match) {
-      case '%d':
-        if (typeof val === 'number') return val
-        throw new Error('Expected a number')
-      case '%s':
-        if (typeof val === 'string') return val
-        throw new Error('Expected a string')
-      case '%c':
-        if (['<', '>', '<=', '>='].includes(val)) return val
-        throw new Error('Expected a compare op')
-      case '%j':
-        if ([Infinity, -Infinity, NaN, undefined].includes(val)) return `${val}`
-        return JSON.stringify(val)
-    }
-    throw new Error(`Unreachable`)
-  })
-  if (args.length !== 0) throw new Error('Unexpected arguments count')
-  return res
-}
 
 module.exports = () => {
   const lines = []

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-const jaystring = require('./jaystring')
 const genfun = require('./generate-function')
 const { toPointer, resolveReference, joinPath } = require('./pointer')
 const formats = require('./formats')
@@ -219,7 +218,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     } else if (defaultIsPresent || booleanRequired) {
       fun.write('if (%s === undefined) {', name)
       if (defaultIsPresent) {
-        fun.write('%s = %s', name, jaystring(node.default))
+        fun.write('%s = %j', name, node.default)
         consume('default')
       }
       if (booleanRequired) {

--- a/src/index.js
+++ b/src/index.js
@@ -290,7 +290,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     const checkNumbers = () => {
       const applyMinMax = (value, operator, message) => {
         enforce(Number.isFinite(value), 'Invalid minimum or maximum:', value)
-        errorIf('!(%d %s %s)', [value, operator, name], message)
+        errorIf('!(%d %c %s)', [value, operator, name], message)
       }
 
       if (Number.isFinite(node.exclusiveMinimum)) {

--- a/src/index.js
+++ b/src/index.js
@@ -116,9 +116,9 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
         if (verboseErrors) {
           const type = node.type || 'any'
           Object.assign(errorObject, { type, schemaPath: toPointer(schemaPath) })
-          writeErrorObject('{ ...%s, value: %s }', JSON.stringify(errorObject), value || name)
+          writeErrorObject('{ ...%j, value: %s }', errorObject, value || name)
         } else {
-          writeErrorObject('%s', JSON.stringify(errorObject))
+          writeErrorObject('%j', errorObject)
         }
       }
       if (allErrors) {

--- a/src/safe-format.js
+++ b/src/safe-format.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const format = (fmt, ...args) => {
+  const res = fmt.replace(/%[%dscj]/g, (match) => {
+    if (match === '%%') return '%'
+    if (args.length === 0) throw new Error('Unexpected arguments count')
+    const val = args.shift()
+    switch (match) {
+      case '%d':
+        if (typeof val === 'number') return val
+        throw new Error('Expected a number')
+      case '%s':
+        if (typeof val === 'string') return val
+        throw new Error('Expected a string')
+      case '%c':
+        if (['<', '>', '<=', '>='].includes(val)) return val
+        throw new Error('Expected a compare op')
+      case '%j':
+        if ([Infinity, -Infinity, NaN, undefined].includes(val)) return `${val}`
+        return JSON.stringify(val)
+    }
+    throw new Error(`Unreachable`)
+  })
+  if (args.length !== 0) throw new Error('Unexpected arguments count')
+  return res
+}
+
+module.exports = { format }


### PR DESCRIPTION
Significantly reduces the codepath (`util.format` is _huge_).
Adds type safeguards.

E.g. `fun.write('%s', {})` and `fun.write('%s')` now fail.