### PR TITLE
No need to import URL, it's available on global object

### DIFF
--- a/src/pointer.js
+++ b/src/pointer.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { URL } = require('url')
-
 function toPointer(path) {
   if (path.length === 0) return ''
   return `#/${path.map((part) => `${part}`.replace(/~/g, '~0').replace(/\//g, '~1')).join('/')}`


### PR DESCRIPTION
Since Node.js 10.

Simplifies bundling (in case if we need that) and now will work in browsers, too (with #96).