### PR TITLE
applyDefault -> useDefaults

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ const rootMeta = new WeakMap()
 const compile = (schema, root, opts, scope, basePathRoot) => {
   const {
     mode = 'default',
-    applyDefault = false,
+    useDefaults = false,
     includeErrors: optIncludeErrors = false,
     allErrors: optAllErrors = false,
     verboseErrors = false,
@@ -209,8 +209,8 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     }
 
     const booleanRequired = getMeta().booleanRequired && typeof node.required === 'boolean'
-    if (node.default !== undefined && !applyDefault) consume('default') // unused in this case
-    const defaultIsPresent = node.default !== undefined && applyDefault // will consume on use
+    if (node.default !== undefined && !useDefaults) consume('default') // unused in this case
+    const defaultIsPresent = node.default !== undefined && useDefaults // will consume on use
     if (isTopLevel) {
       // top-level data is coerced to null above, it can't be undefined
       if (defaultIsPresent) fail('Can not apply default value at root')


### PR DESCRIPTION
Follow ajv naming.

Looks like I made a mistake in #52 on the naming part.
Probably because of https://github.com/ajv-validator/ajv/issues/75.

The correct name is `useDefaults`: https://github.com/ajv-validator/ajv#assigning-defaults