### PR TITLE
Support only functions and regexps in jaystring

### DIFF
--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -1,49 +1,26 @@
 const isArrowFnWithParensRegex = /^\([^)]*\) *=>/
 const isArrowFnWithoutParensRegex = /^[^=]*=>/
 
-const stringify = {
-  string: (s) => JSON.stringify(s),
-  number: (n) => String(n),
-  boolean: (b) => String(b),
-  undefined: () => 'undefined',
-  array: (array) => `[${array.map(jaystring).join(',')}]`,
-  date: (date) => `new Date(${date.getTime()})`,
+// Supports only functions and regexps, for scope
 
-  function: (func) => {
-    if (Object.getPrototypeOf(func) !== Function.prototype)
+function jaystring(item) {
+  if (typeof item === 'function') {
+    if (Object.getPrototypeOf(item) !== Function.prototype)
       throw new Error('Can not stringify a function with unexpected prototype')
 
-    const stringified = `${func}`
-    if (func.prototype) return stringified // normal function
+    const stringified = `${item}`
+    if (item.prototype) return stringified // normal function
     if (isArrowFnWithParensRegex.test(stringified) || isArrowFnWithoutParensRegex.test(stringified))
       return stringified // Arrow function
 
     // Shortened ES6 object method declaration
     return `function ${stringified}`
-  },
-
-  object: (obj) => {
-    if (obj === null) return 'null'
-    const proto = Object.getPrototypeOf(obj)
-
-    if (Array.isArray(obj) && proto === Array.prototype) return stringify.array(obj)
-    if (obj instanceof Date && proto === Date.prototype) return stringify.date(obj)
-    if (obj instanceof RegExp && proto === RegExp.prototype) return String(obj)
-
-    if (proto === Object.prototype || proto === null) {
-      const parts = Object.entries(obj)
-      return `{${parts.map(([key, val]) => `${JSON.stringify(key)}:${jaystring(val)}`).join(',')}}`
-    }
-
+  } else if (typeof item === 'object') {
+    const proto = Object.getPrototypeOf(item)
+    if (item instanceof RegExp && proto === RegExp.prototype) return String(item)
     throw new Error('Can not stringify an object with unexpected prototype')
-  },
-}
-
-function jaystring(item) {
-  const type = typeof item
-  const toString = stringify.hasOwnProperty(type) ? stringify[type] : null
-  if (!toString) throw new Error(`Cannot stringify ${item} - unknown type ${typeof item}`)
-  return toString(item)
+  }
+  throw new Error(`Cannot stringify ${item} - unknown type ${typeof item}`)
 }
 
 module.exports = jaystring

--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -37,8 +37,6 @@ const stringify = {
 
     throw new Error('Can not stringify an object with unexpected prototype')
   },
-
-  symbol: (symbol) => `Symbol(${JSON.stringify(symbol.description)})`,
 }
 
 function jaystring(item) {


### PR DESCRIPTION
We don't need anything else for scope, better to exclude all that.

Depends on #96 to remove `jaystring` usage from `defaults`.