### PR TITLE
Drop support for object methods + additional safeguard

### DIFF
--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -9,12 +9,15 @@ function jaystring(item) {
       throw new Error('Can not stringify a function with unexpected prototype')
 
     const stringified = `${item}`
-    if (item.prototype) return stringified // normal function
+    if (item.prototype) {
+      if (!/^function[ (]/.test(stringified)) throw new Error('Unexpected function')
+      return stringified // normal function
+    }
     if (isArrowFnWithParensRegex.test(stringified) || isArrowFnWithoutParensRegex.test(stringified))
       return stringified // Arrow function
 
     // Shortened ES6 object method declaration
-    return `function ${stringified}`
+    throw new Error('Can stringify only either normal or arrow functions')
   } else if (typeof item === 'object') {
     const proto = Object.getPrototypeOf(item)
     if (item instanceof RegExp && proto === RegExp.prototype) return String(item)


### PR DESCRIPTION
We can't be sure to always work on object methods, => can give false positives.

This doesn't fix those, but doesn't make it appear as if object methods are supported in the first place.

While this solution is not ideal, I think it's better than what we had.